### PR TITLE
fix: create mount point directories in distroless image and align crypto store path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN CGO_ENABLED=0 go build -tags goolm -trimpath \
 # volumes over these paths at runtime. Without them in the image the behaviour
 # is runtime-implementation-specific — creating them here makes the contract
 # explicit and portable.
-RUN mkdir -p /staging/var/lib/bridge /staging/run/secrets/anthropic
+RUN install -d -m 0700 /staging/var/lib/bridge && \
+    mkdir -p /staging/run/secrets/anthropic
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -54,7 +54,7 @@ func main() {
 		Homeserver:   mustEnv("MATRIX_HOMESERVER", ""),
 		Username:     mustEnv("MATRIX_USERNAME", ""),
 		Password:     mustEnv("MATRIX_PASSWORD", ""),
-		CryptoDBPath: mustEnv("CRYPTO_DB_PATH", "/var/lib/bridge/bridge.db"),
+		CryptoDBPath: mustEnv("CRYPTO_DB_PATH", bot.DefaultCryptoDBPath),
 		PickleKey:    mustEnv("PICKLE_KEY", ""),
 		DisplayName:  "Bridge",
 		KnownCrew:    registry.IDs(),

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -34,6 +34,10 @@ type Sender interface {
 	Send(ctx context.Context, roomID id.RoomID, resp *orchestrator.Response) error
 }
 
+// DefaultCryptoDBPath is the default path for the E2EE crypto store SQLite DB.
+// It must match the PVC mount path configured in the Helm chart (cryptoStore.mountPath).
+const DefaultCryptoDBPath = "/var/lib/bridge/bridge.db"
+
 // Config holds bot connection parameters.
 type Config struct {
 	Homeserver   string
@@ -57,7 +61,7 @@ type Bot struct {
 // New creates a Bot but does not connect yet.
 func New(cfg Config, orch OrchestratorI) (*Bot, error) {
 	if cfg.CryptoDBPath == "" {
-		cfg.CryptoDBPath = "/var/lib/bridge/bridge.db"
+		cfg.CryptoDBPath = DefaultCryptoDBPath
 	}
 	if cfg.DisplayName == "" {
 		cfg.DisplayName = "Bridge"

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -79,8 +79,8 @@ func TestNewDefaultsCryptoDBPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if b.cfg.CryptoDBPath == "" {
-		t.Error("expected non-empty default CryptoDBPath")
+	if b.cfg.CryptoDBPath != DefaultCryptoDBPath {
+		t.Errorf("expected default CryptoDBPath %q, got %q", DefaultCryptoDBPath, b.cfg.CryptoDBPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Creates `/var/lib/bridge` and `/run/secrets/anthropic` as empty directories in the builder stage and COPYs them into the distroless final image, so mount point directories exist in the image layer rather than relying on runtime behaviour
- Aligns the default `CRYPTO_DB_PATH` in `bot.go` and `main.go` with the Helm chart's `cryptoStore.mountPath` (`/var/lib/bridge/bridge.db`)

Caught during Copilot review of the AKeyRA helm/bridge chart (klazomenai/AKeyRA#26).

Refs #11

## Test plan

- [ ] `docker build` succeeds (CI)
- [ ] `go build -tags goolm ./...` passes (CI)
- [ ] All unit tests pass, coverage ≥ 70% (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)