### PR TITLE
feat(crew): add Bosun and Lookout crew members ⛵

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -83,6 +83,15 @@ func main() {
 		slog.Info("crest: email tools registered as stubs (CREST_IMAP_HOST not set)")
 	}
 
+	// --- Bosun tools ---
+	toolReg.Register(tools.NewStubTool("kubectl_get", "Get Kubernetes resources (not configured)"))
+	slog.Info("bosun: tools registered as stubs")
+
+	// --- Lookout tools ---
+	toolReg.Register(tools.NewStubTool("prometheus_query", "Query Prometheus metrics (not configured)"))
+	toolReg.Register(tools.NewStubTool("loki_query", "Query Loki logs (not configured)"))
+	slog.Info("lookout: tools registered as stubs")
+
 	// --- Crew registry ---
 	registryPath := mustEnv("CREW_REGISTRY_PATH", "/config/crew.yaml")
 	registry, err := crew.Load(registryPath)

--- a/config/crew.yaml
+++ b/config/crew.yaml
@@ -34,3 +34,35 @@ crew:
       precise diction. "Signal received. Contents verified."
       The Captain's message will be prefixed "The Captain says:".
       Respond in {verbosity}
+
+  bosun:
+    name: "Bosun"
+    role: "Deck Supervisor"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    tools: [delegate_to_crew, kubectl_get]
+    voice:
+      model: "en_GB-alan-medium.onnx"
+      announces_as: "Bosun:"
+    system_prompt: |
+      You are Bosun, the Deck Supervisor. You keep order on deck, inspect
+      rigging, and maintain the watch. Methodical, authoritative, no-nonsense.
+      "All hands accounted for. Deck secure."
+      The Captain's message will be prefixed "The Captain says:".
+      Respond in {verbosity}
+
+  lookout:
+    name: "Lookout"
+    role: "Watch"
+    model: "claude-haiku-4-5"
+    verbosity: signal
+    tools: [delegate_to_crew, prometheus_query, loki_query]
+    voice:
+      model: "en_US-amy-medium.onnx"
+      announces_as: "Lookout:"
+    system_prompt: |
+      You are the Lookout, posted at the crow's nest. You scan the horizon,
+      report what you see — terse, factual, urgent when needed.
+      "Sail on the horizon, bearing south-south-west."
+      The Captain's message will be prefixed "The Captain says:".
+      Respond in {verbosity}

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -193,6 +193,30 @@ func TestExtractCrewRequestWordBoundary(t *testing.T) {
 	}
 }
 
+func TestExtractCrewRequestBosun(t *testing.T) {
+	crew := []string{"maren", "crest", "bosun", "lookout"}
+	got := extractCrewRequest("over to bosun", crew)
+	if got != "bosun" {
+		t.Errorf("expected bosun, got %q", got)
+	}
+}
+
+func TestExtractCrewRequestLookoutComma(t *testing.T) {
+	crew := []string{"maren", "crest", "bosun", "lookout"}
+	got := extractCrewRequest("lookout, status report", crew)
+	if got != "lookout" {
+		t.Errorf("expected lookout, got %q", got)
+	}
+}
+
+func TestExtractCrewRequestLookoutColon(t *testing.T) {
+	crew := []string{"maren", "crest", "bosun", "lookout"}
+	got := extractCrewRequest("lookout: check the metrics", crew)
+	if got != "lookout" {
+		t.Errorf("expected lookout, got %q", got)
+	}
+}
+
 // --- handleMessage tests using mocks ---
 
 // mockOrch is a test double for OrchestratorI.
@@ -254,7 +278,7 @@ func newTestBotWithTyper(t *testing.T, orch OrchestratorI, sender Sender, typer 
 		typer:  typer,
 		cfg: Config{
 			Username:  string(selfUserID),
-			KnownCrew: []string{"maren", "crest"},
+			KnownCrew: []string{"maren", "crest", "bosun", "lookout"},
 		},
 	}
 }

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -30,6 +30,24 @@ crew:
       model: "en_US-lessac-high.onnx"
       announces_as: "Crest:"
     system_prompt: "You are Crest. Respond in {verbosity}"
+  bosun:
+    name: "Bosun"
+    role: "Deck Supervisor"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    voice:
+      model: "en_GB-alan-medium.onnx"
+      announces_as: "Bosun:"
+    system_prompt: "You are Bosun. Respond in {verbosity}"
+  lookout:
+    name: "Lookout"
+    role: "Watch"
+    model: "claude-haiku-4-5"
+    verbosity: signal
+    voice:
+      model: "en_US-amy-medium.onnx"
+      announces_as: "Lookout:"
+    system_prompt: "You are the Lookout. Respond in {verbosity}"
 `
 
 func writeRegistry(t *testing.T, content string) string {
@@ -320,17 +338,75 @@ func TestRegistryIDs(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	ids := r.IDs()
-	if len(ids) != 2 {
-		t.Fatalf("expected 2 crew IDs, got %d: %v", len(ids), ids)
+	if len(ids) != 4 {
+		t.Fatalf("expected 4 crew IDs, got %d: %v", len(ids), ids)
 	}
 	seen := make(map[string]bool)
 	for _, id := range ids {
 		seen[id] = true
 	}
-	for _, want := range []string{"maren", "crest"} {
+	for _, want := range []string{"maren", "crest", "bosun", "lookout"} {
 		if !seen[want] {
 			t.Errorf("expected ID %q in IDs(), got %v", want, ids)
 		}
+	}
+}
+
+func TestBosunAndLookoutGetters(t *testing.T) {
+	path := writeRegistry(t, validYAML)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	bosun := r.Get("bosun")
+	if bosun == nil {
+		t.Fatal("bosun not found")
+	}
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"ID", bosun.ID(), "bosun"},
+		{"Name", bosun.Name(), "Bosun"},
+		{"Role", bosun.Role(), "Deck Supervisor"},
+		{"Model", bosun.Model(), "claude-sonnet-4-6"},
+		{"Verbosity", bosun.Verbosity(), "log-entry"},
+		{"AnnouncesAs", bosun.AnnouncesAs(), "Bosun:"},
+		{"VoiceModel", bosun.VoiceModel(), "en_GB-alan-medium.onnx"},
+	}
+	for _, c := range checks {
+		t.Run("Bosun/"+c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("got %q, want %q", c.got, c.want)
+			}
+		})
+	}
+
+	lookout := r.Get("lookout")
+	if lookout == nil {
+		t.Fatal("lookout not found")
+	}
+	lookoutChecks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"ID", lookout.ID(), "lookout"},
+		{"Name", lookout.Name(), "Lookout"},
+		{"Role", lookout.Role(), "Watch"},
+		{"Model", lookout.Model(), "claude-haiku-4-5"},
+		{"Verbosity", lookout.Verbosity(), "signal"},
+		{"AnnouncesAs", lookout.AnnouncesAs(), "Lookout:"},
+		{"VoiceModel", lookout.VoiceModel(), "en_US-amy-medium.onnx"},
+	}
+	for _, c := range lookoutChecks {
+		t.Run("Lookout/"+c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("got %q, want %q", c.got, c.want)
+			}
+		})
 	}
 }
 
@@ -377,6 +453,26 @@ crew:
       model: "en_US-lessac-high.onnx"
       announces_as: "Crest:"
     system_prompt: "You are Crest. Respond in {verbosity}"
+  bosun:
+    name: "Bosun"
+    role: "Deck Supervisor"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    tools: [kubectl_get]
+    voice:
+      model: "en_GB-alan-medium.onnx"
+      announces_as: "Bosun:"
+    system_prompt: "You are Bosun. Respond in {verbosity}"
+  lookout:
+    name: "Lookout"
+    role: "Watch"
+    model: "claude-haiku-4-5"
+    verbosity: signal
+    tools: [prometheus_query, loki_query]
+    voice:
+      model: "en_US-amy-medium.onnx"
+      announces_as: "Lookout:"
+    system_prompt: "You are the Lookout. Respond in {verbosity}"
 `
 
 func TestToolsParsedFromYAML(t *testing.T) {
@@ -427,9 +523,11 @@ func TestValidateToolsAllPresent(t *testing.T) {
 	}
 
 	checker := &stubChecker{known: map[string]bool{
-		"kubectl_get": true,
-		"helm_status": true,
-		"imap_poll":   true,
+		"kubectl_get":      true,
+		"helm_status":      true,
+		"imap_poll":        true,
+		"prometheus_query": true,
+		"loki_query":       true,
 	}}
 	if err := r.ValidateTools(checker); err != nil {
 		t.Fatalf("expected no error, got: %v", err)


### PR DESCRIPTION
## Summary

- Add Bosun (Deck Supervisor) and Lookout (Watch) to `config/crew.yaml`, expanding crew roster from 2 to 4
- Register `kubectl_get`, `prometheus_query`, and `loki_query` as stub tools in `cmd/bridge/main.go`
- Add crew registry tests (getters, IDs, tool validation) and bot routing tests (`over to bosun`, `lookout,` prefix, `lookout:` prefix)

## Test plan

- [x] `go test -tags goolm -race ./...` clean
- [x] `go vet -tags goolm ./...` clean
- [x] crew.yaml loads all 4 crew, ValidateTools passes
- [x] Routing tests verify "over to bosun" and "lookout, ..." patterns
- [x] CI green

Refs #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)