### PR TITLE
feat(crew): add Chips the Carpenter crew member ⛵

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -92,6 +92,16 @@ func main() {
 	toolReg.Register(tools.NewStubTool("loki_query", "Query Loki logs (not configured)"))
 	slog.Info("lookout: tools registered as stubs")
 
+	// --- Chips tools ---
+	toolReg.Register(tools.NewStubTool("gh_issue_list", "List GitHub issues (not configured)"))
+	toolReg.Register(tools.NewStubTool("gh_issue_view", "View a GitHub issue (not configured)"))
+	toolReg.Register(tools.NewStubTool("gh_pr_list", "List GitHub pull requests (not configured)"))
+	toolReg.Register(tools.NewStubTool("gh_pr_view", "View a GitHub pull request (not configured)"))
+	toolReg.Register(tools.NewStubTool("gh_pr_checks", "Check PR CI status (not configured)"))
+	toolReg.Register(tools.NewStubTool("git_log", "View recent git commits (not configured)"))
+	toolReg.Register(tools.NewStubTool("git_diff", "View git diff between refs (not configured)"))
+	slog.Info("chips: tools registered as stubs")
+
 	// --- Crew registry ---
 	registryPath := mustEnv("CREW_REGISTRY_PATH", "/config/crew.yaml")
 	registry, err := crew.Load(registryPath)

--- a/config/crew.yaml
+++ b/config/crew.yaml
@@ -66,3 +66,21 @@ crew:
       "Sail on the horizon, bearing south-south-west."
       The Captain's message will be prefixed "The Captain says:".
       Respond in {verbosity}
+
+  chips:
+    name: "Chips"
+    role: "The Carpenter"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    tools: [delegate_to_crew, gh_issue_list, gh_issue_view, gh_pr_list, gh_pr_view, gh_pr_checks, git_log, git_diff]
+    voice:
+      model: TBD
+      announces_as: "Chips:"
+    system_prompt: |
+      You are Chips, the ship's Carpenter. You work the timber — the code,
+      the repositories, the issues and pull requests. Methodical,
+      detail-oriented. You measure twice, cut once. You speak in
+      woodworking metaphors: joints, grain, dovetails, planks.
+      "That joint won't hold in heavy seas, Captain."
+      The Captain's message will be prefixed "The Captain says:".
+      Respond in {verbosity}

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -217,6 +217,56 @@ func TestExtractCrewRequestLookoutColon(t *testing.T) {
 	}
 }
 
+func TestExtractCrewRequestMultipleOverToPicksEarliest(t *testing.T) {
+	crew := []string{"maren", "crest", "bosun", "lookout", "chips"}
+
+	msgCrestFirst := "over to crest for comms, then over to chips for the PR"
+	got := extractCrewRequest(msgCrestFirst, crew)
+	if got != "crest" {
+		t.Errorf("expected crest (earliest match), got %q", got)
+	}
+
+	// Reverse scenario: chips appears first.
+	msgChipsFirst := "over to chips first, then over to bosun"
+	got = extractCrewRequest(msgChipsFirst, crew)
+	if got != "chips" {
+		t.Errorf("expected chips (earliest match), got %q", got)
+	}
+
+	// Verify that changing the known crew slice order does not affect routing.
+	// Reverse the crew slice to simulate non-deterministic map iteration order.
+	reversed := make([]string, len(crew))
+	for i := range crew {
+		reversed[i] = crew[len(crew)-1-i]
+	}
+
+	got = extractCrewRequest(msgCrestFirst, reversed)
+	if got != "crest" {
+		t.Errorf("with reversed crew slice, expected crest (earliest match), got %q", got)
+	}
+
+	got = extractCrewRequest(msgChipsFirst, reversed)
+	if got != "chips" {
+		t.Errorf("with reversed crew slice, expected chips (earliest match), got %q", got)
+	}
+}
+
+func TestExtractCrewRequestChipsOverTo(t *testing.T) {
+	crew := []string{"maren", "crest", "bosun", "lookout", "chips"}
+	got := extractCrewRequest("over to chips", crew)
+	if got != "chips" {
+		t.Errorf("expected chips, got %q", got)
+	}
+}
+
+func TestExtractCrewRequestChipsComma(t *testing.T) {
+	crew := []string{"maren", "crest", "bosun", "lookout", "chips"}
+	got := extractCrewRequest("chips, check the PR", crew)
+	if got != "chips" {
+		t.Errorf("expected chips, got %q", got)
+	}
+}
+
 // --- handleMessage tests using mocks ---
 
 // mockOrch is a test double for OrchestratorI.
@@ -278,7 +328,7 @@ func newTestBotWithTyper(t *testing.T, orch OrchestratorI, sender Sender, typer 
 		typer:  typer,
 		cfg: Config{
 			Username:  string(selfUserID),
-			KnownCrew: []string{"maren", "crest", "bosun", "lookout"},
+			KnownCrew: []string{"maren", "crest", "bosun", "lookout", "chips"},
 		},
 	}
 }

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -168,8 +168,10 @@ func extractCrewRequest(text string, knownCrew []string) string {
 	lower := strings.ToLower(text)
 
 	// "Over to <crew>" overrides prefix routing — check this first.
-	// Require a word boundary after the crew ID to avoid matching partial words
-	// (e.g. "crest" must not match "over to crestfallen").
+	// When multiple "over to" mentions exist, pick the earliest match in the
+	// message so routing is deterministic regardless of knownCrew slice order.
+	bestIdx := -1
+	bestCrew := ""
 	for _, c := range knownCrew {
 		phrase := "over to " + c
 		idx := strings.Index(lower, phrase)
@@ -178,8 +180,14 @@ func extractCrewRequest(text string, knownCrew []string) string {
 		}
 		after := idx + len(phrase)
 		if after == len(lower) || !isWordChar(rune(lower[after])) {
-			return c
+			if bestIdx == -1 || idx < bestIdx {
+				bestIdx = idx
+				bestCrew = c
+			}
 		}
+	}
+	if bestCrew != "" {
+		return bestCrew
 	}
 
 	// Prefix routing: "<crew>," or "<crew>:".

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -48,6 +48,15 @@ crew:
       model: "en_US-amy-medium.onnx"
       announces_as: "Lookout:"
     system_prompt: "You are the Lookout. Respond in {verbosity}"
+  chips:
+    name: "Chips"
+    role: "The Carpenter"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    voice:
+      model: TBD
+      announces_as: "Chips:"
+    system_prompt: "You are Chips. Respond in {verbosity}"
 `
 
 func writeRegistry(t *testing.T, content string) string {
@@ -338,14 +347,14 @@ func TestRegistryIDs(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	ids := r.IDs()
-	if len(ids) != 4 {
-		t.Fatalf("expected 4 crew IDs, got %d: %v", len(ids), ids)
+	if len(ids) != 5 {
+		t.Fatalf("expected 5 crew IDs, got %d: %v", len(ids), ids)
 	}
 	seen := make(map[string]bool)
 	for _, id := range ids {
 		seen[id] = true
 	}
-	for _, want := range []string{"maren", "crest", "bosun", "lookout"} {
+	for _, want := range []string{"maren", "crest", "bosun", "lookout", "chips"} {
 		if !seen[want] {
 			t.Errorf("expected ID %q in IDs(), got %v", want, ids)
 		}
@@ -473,6 +482,16 @@ crew:
       model: "en_US-amy-medium.onnx"
       announces_as: "Lookout:"
     system_prompt: "You are the Lookout. Respond in {verbosity}"
+  chips:
+    name: "Chips"
+    role: "The Carpenter"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    tools: [gh_issue_list, gh_issue_view, gh_pr_list, gh_pr_view, gh_pr_checks, git_log, git_diff]
+    voice:
+      model: TBD
+      announces_as: "Chips:"
+    system_prompt: "You are Chips. Respond in {verbosity}"
 `
 
 func TestToolsParsedFromYAML(t *testing.T) {
@@ -528,6 +547,13 @@ func TestValidateToolsAllPresent(t *testing.T) {
 		"imap_poll":        true,
 		"prometheus_query": true,
 		"loki_query":       true,
+		"gh_issue_list":    true,
+		"gh_issue_view":    true,
+		"gh_pr_list":       true,
+		"gh_pr_view":       true,
+		"gh_pr_checks":     true,
+		"git_log":          true,
+		"git_diff":         true,
 	}}
 	if err := r.ValidateTools(checker); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -568,5 +594,40 @@ func TestValidateToolsNoToolsDeclared(t *testing.T) {
 	checker := &stubChecker{known: map[string]bool{}}
 	if err := r.ValidateTools(checker); err != nil {
 		t.Fatalf("expected no error when no tools declared, got: %v", err)
+	}
+}
+
+// TestRealCrewYAMLLoadsAndValidates loads the repository's config/crew.yaml
+// and validates all declared tools against the known registration set. This
+// catches config/registration drift that synthetic test YAML would miss.
+func TestRealCrewYAMLLoadsAndValidates(t *testing.T) {
+	const configPath = "../../config/crew.yaml"
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("config/crew.yaml not found at %s (running outside repo?)", configPath)
+	}
+
+	r, err := crew.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load real crew.yaml: %v", err)
+	}
+
+	// All tool names that main.go registers (real or stub).
+	allTools := &stubChecker{known: map[string]bool{
+		"delegate_to_crew":  true,
+		"imap_poll":         true,
+		"smtp_send":         true,
+		"kubectl_get":       true,
+		"prometheus_query":  true,
+		"loki_query":        true,
+		"gh_issue_list":     true,
+		"gh_issue_view":     true,
+		"gh_pr_list":        true,
+		"gh_pr_view":        true,
+		"gh_pr_checks":      true,
+		"git_log":           true,
+		"git_diff":          true,
+	}}
+	if err := r.ValidateTools(allTools); err != nil {
+		t.Fatalf("real crew.yaml tool validation failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Add Chips (The Carpenter) to `config/crew.yaml`, expanding crew roster from 4 to 5
- Register 7 read-only GitHub tool stubs in `cmd/bridge/main.go`: `gh_issue_list`, `gh_issue_view`, `gh_pr_list`, `gh_pr_view`, `gh_pr_checks`, `git_log`, `git_diff`
- Add crew registry tests (getters, IDs, tool validation) and bot routing tests (`over to chips`, `chips,` prefix)

## Test plan

- [x] `go test -tags goolm -race ./...` clean
- [x] `go vet -tags goolm ./...` clean
- [x] crew.yaml loads all 5 crew, ValidateTools passes
- [x] Routing tests verify "over to chips" and "chips, ..." patterns
- [x] CI green

Refs #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)