### PR TITLE
fix: prepend crew metadata body prefix for deck-chat compatibility 🐛

### DIFF
--- a/internal/bot/sender.go
+++ b/internal/bot/sender.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"maunium.net/go/mautrix"
@@ -36,6 +37,13 @@ type matrixSender struct {
 	client *mautrix.Client
 }
 
+// formatBody prepends crew metadata as a body prefix so that clients using
+// typed Matrix SDKs (which strip custom JSON fields) can identify the crew
+// member and verbosity level. Format: [crewID:verbosity] text
+func formatBody(crewID, verbosity, text string) string {
+	return fmt.Sprintf("[%s:%s] %s", crewID, verbosity, text)
+}
+
 func (s *matrixSender) Send(ctx context.Context, roomID id.RoomID, resp *orchestrator.Response) error {
 	_, err := s.client.SendMessageEvent(ctx, roomID, event.EventMessage, struct {
 		MsgType    event.MessageType `json:"msgtype"`
@@ -44,7 +52,7 @@ func (s *matrixSender) Send(ctx context.Context, roomID id.RoomID, resp *orchest
 		Verbosity  string            `json:"verbosity"`
 	}{
 		MsgType:    event.MsgText,
-		Body:       resp.Text,
+		Body:       formatBody(resp.CrewID, resp.Verbosity, resp.Text),
 		CrewMember: resp.CrewID,
 		Verbosity:  resp.Verbosity,
 	})

--- a/internal/bot/sender_test.go
+++ b/internal/bot/sender_test.go
@@ -1,0 +1,44 @@
+package bot
+
+import "testing"
+
+func TestFormatBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		crewID    string
+		verbosity string
+		text      string
+		want      string
+	}{
+		{
+			name:      "standard crew response",
+			crewID:    "maren",
+			verbosity: "dispatch",
+			text:      "Aye, the hull looks sound today.",
+			want:      "[maren:dispatch] Aye, the hull looks sound today.",
+		},
+		{
+			name:      "different crew and verbosity",
+			crewID:    "crest",
+			verbosity: "detail",
+			text:      "Signal received from port.",
+			want:      "[crest:detail] Signal received from port.",
+		},
+		{
+			name:      "empty text",
+			crewID:    "bosun",
+			verbosity: "dispatch",
+			text:      "",
+			want:      "[bosun:dispatch] ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatBody(tt.crewID, tt.verbosity, tt.text)
+			if got != tt.want {
+				t.Errorf("formatBody() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Prepend `[crewID:verbosity]` prefix to Matrix message body in `sender.go`
- Extract `formatBody()` helper for testability
- Add table-driven tests in `sender_test.go`
- Retain custom JSON fields (`crew_member`, `verbosity`) for future raw-event access

### Before
```
body: "Aye, the hull looks sound today."
```
deck-chat has no crew metadata — all responses fall back to Maren voice.

### After
```
body: "[maren:dispatch] Aye, the hull looks sound today."
```
deck-chat parses the prefix via regex and routes to the correct crew voice.

## Test plan

- [x] `go test -tags goolm ./internal/bot/...` passes
- [x] `go test -tags goolm ./internal/...` passes (all tests)
- [x] CI lint + test + docker build passes
- [ ] End-to-end: deploy to cluster, verify deck-chat receives prefixed messages and routes to correct voice

Refs #73
