### PR TITLE
chore: add nautical theming to release-please config 🗺️

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
   "include-component-in-tag": false,
   "pull-request-title-pattern": "chore${scope}: release${component} ${version} 🗺️",
   "pull-request-header": "🏴‍☠️ All hands on deck! New cargo manifest ready for inspection",
-  "pull-request-footer": "🏴‍☠️ Logged by the [Quartermaster](https://github.com/googleapis/release-please). All hands review before we set sail.",
+  "pull-request-footer": "🏴‍☠️ Logged by the [Quartermaster](../../.github/workflows/RELEASE-PLEASE.md). All hands review before we set sail.",
   "changelog-sections": [
     {"type": "feat", "section": "⛵ New Rigging", "hidden": false},
     {"type": "fix", "section": "🔧 Hull Repairs", "hidden": false},


### PR DESCRIPTION
## Summary

Add pirate-themed customisation to release-please so PR titles, headers, footers, and changelog sections are automatically themed without manual editing.

### Changes

- **PR title**: `chore(main): release 0.1.0-alpha 🗺️`
- **PR header**: 🏴‍☠️ All hands on deck! New cargo manifest ready for inspection
- **PR footer**: 🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
- **Changelog sections**: ⛵ New Rigging | 🔧 Hull Repairs | ⚡ Trimmed the Sails | ♻️ Refitted | ↩️ Struck from the Log | 🔐 Battened Hatches

## Test plan

- [x] CI passes
- [ ] Next release PR uses new title, header, footer automatically
- [ ] Next changelog uses nautical section names

Refs #76