### PR TITLE
feat: swap distroless for Alpine with kubectl and helm ⛵

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,24 +23,23 @@ FROM alpine:3.21
 RUN addgroup -g 65532 bridge && \
     adduser -D -u 65532 -G bridge bridge
 
-# kubectl and helm — pinned versions, compatible with GKE RAPID channel.
+# kubectl and helm — pinned versions and SHA256 hashes for supply-chain integrity.
+# Hashes are verified locally; no trust placed on upstream checksum endpoints.
 # curl removed after install to minimise attack surface.
 ARG KUBECTL_VERSION=v1.33.4
+ARG KUBECTL_SHA256=c2ba72c115d524b72aaee9aab8df8b876e1596889d2f3f27d68405262ce86ca1
 ARG HELM_VERSION=v3.11.1
+ARG HELM_SHA256=0b1be96b66fab4770526f136f5f1a385a47c41923d33aab0dcb500e0f6c1bf7c
 RUN apk add --no-cache ca-certificates curl && \
     curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
       -o /tmp/kubectl && \
-    curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
-      -o /tmp/kubectl.sha256 && \
-    echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum -c - && \
+    echo "${KUBECTL_SHA256}  /tmp/kubectl" | sha256sum -c - && \
     install -m 0755 /tmp/kubectl /usr/local/bin/kubectl && \
     curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
       -o /tmp/helm.tar.gz && \
-    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" \
-      -o /tmp/helm.sha256sum && \
-    awk '{print $1 "  /tmp/helm.tar.gz"}' /tmp/helm.sha256sum | sha256sum -c - && \
+    echo "${HELM_SHA256}  /tmp/helm.tar.gz" | sha256sum -c - && \
     tar xzf /tmp/helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
-    rm -f /tmp/kubectl /tmp/kubectl.sha256 /tmp/helm.tar.gz /tmp/helm.sha256sum && \
+    rm -f /tmp/kubectl /tmp/helm.tar.gz && \
     apk del curl
 
 # Same directory structure as previous distroless build — kubelet mounts

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,27 +7,40 @@ RUN go mod download
 
 COPY . .
 
-# CGO_ENABLED=0: pure-Go binary, distroless-compatible.
+# CGO_ENABLED=0: pure-Go static binary (no libc dependency).
 # -tags goolm: pure-Go olm implementation (no libolm shared library needed).
 RUN CGO_ENABLED=0 go build -tags goolm -trimpath \
     -ldflags="-s -w" \
     -o /out/bridge ./cmd/bridge
 
-# Create empty mount point directories. distroless/static is built from scratch
-# and contains neither /var (e.g. /var/lib/bridge) nor /run; kubelet mounts
-# volumes over these paths at runtime. Without them in the image the behaviour
-# is runtime-implementation-specific — creating them here makes the contract
-# explicit and portable.
-RUN install -d -m 0700 /staging/var/lib/bridge && \
-    mkdir -p /staging/run/secrets/anthropic
+# Alpine runtime — kubectl and helm needed for Maren/Bosun cluster tools.
+# Distroless has no package manager or shell; Alpine is minimal (~7MB) and
+# version-pinned per security skill guidance.
+FROM alpine:3.21
 
-FROM gcr.io/distroless/static:nonroot
+# Non-root user — UID 65532 matches existing deployment securityContext
+# (runAsUser, runAsGroup, fsGroup) so no Helm chart changes needed.
+RUN adduser -D -u 65532 -g 65532 bridge
+
+# kubectl and helm — pinned versions, compatible with GKE RAPID channel.
+# curl removed after install to minimise attack surface.
+ARG KUBECTL_VERSION=v1.32.3
+ARG HELM_VERSION=v3.17.3
+RUN apk add --no-cache ca-certificates curl && \
+    curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | \
+      tar xz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
+    apk del curl
+
+# Same directory structure as previous distroless build — kubelet mounts
+# volumes over these paths at runtime.
+RUN install -d -m 0700 -o bridge -g bridge /var/lib/bridge && \
+    mkdir -p /run/secrets/anthropic
 
 COPY --from=builder /out/bridge /bridge
-COPY --chown=65532:65532 --from=builder /staging/var/lib/bridge /var/lib/bridge
-COPY --from=builder /staging/run/secrets/anthropic /run/secrets/anthropic
 COPY config/crew.yaml /config/crew.yaml
 
-USER nonroot
+USER bridge
 
 ENTRYPOINT ["/bridge"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache ca-certificates curl && \
       -o /tmp/helm.tar.gz && \
     curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" \
       -o /tmp/helm.sha256sum && \
-    sed 's# linux-amd64.tar.gz#  /tmp/helm.tar.gz#' /tmp/helm.sha256sum | sha256sum -c - && \
+    awk '{print $1 "  /tmp/helm.tar.gz"}' /tmp/helm.sha256sum | sha256sum -c - && \
     tar xzf /tmp/helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
     rm -f /tmp/kubectl /tmp/kubectl.sha256 /tmp/helm.tar.gz /tmp/helm.sha256sum && \
     apk del curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ RUN CGO_ENABLED=0 go build -tags goolm -trimpath \
 # version-pinned per security skill guidance.
 FROM alpine:3.21
 
-# Non-root user — UID 65532 matches existing deployment securityContext
+# Non-root user — UID/GID 65532 matches existing deployment securityContext
 # (runAsUser, runAsGroup, fsGroup) so no Helm chart changes needed.
-RUN adduser -D -u 65532 -g 65532 bridge
+RUN addgroup -g 65532 bridge && \
+    adduser -D -u 65532 -G bridge bridge
 
 # kubectl and helm — pinned versions, compatible with GKE RAPID channel.
 # curl removed after install to minimise attack surface.
@@ -28,9 +29,18 @@ ARG KUBECTL_VERSION=v1.33.4
 ARG HELM_VERSION=v3.11.1
 RUN apk add --no-cache ca-certificates curl && \
     curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
-      -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
-    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | \
-      tar xz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
+      -o /tmp/kubectl && \
+    curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+      -o /tmp/kubectl.sha256 && \
+    echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum -c - && \
+    install -m 0755 /tmp/kubectl /usr/local/bin/kubectl && \
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+      -o /tmp/helm.tar.gz && \
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" \
+      -o /tmp/helm.sha256sum && \
+    sed 's# linux-amd64.tar.gz#  /tmp/helm.tar.gz#' /tmp/helm.sha256sum | sha256sum -c - && \
+    tar xzf /tmp/helm.tar.gz -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
+    rm -f /tmp/kubectl /tmp/kubectl.sha256 /tmp/helm.tar.gz /tmp/helm.sha256sum && \
     apk del curl
 
 # Same directory structure as previous distroless build — kubelet mounts

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN adduser -D -u 65532 -g 65532 bridge
 
 # kubectl and helm — pinned versions, compatible with GKE RAPID channel.
 # curl removed after install to minimise attack surface.
-ARG KUBECTL_VERSION=v1.32.3
-ARG HELM_VERSION=v3.17.3
+ARG KUBECTL_VERSION=v1.33.4
+ARG HELM_VERSION=v3.11.1
 RUN apk add --no-cache ca-certificates curl && \
     curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
       -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \


### PR DESCRIPTION
## Summary

- Replace `gcr.io/distroless/static:nonroot` with `alpine:3.21`
- Add pinned kubectl v1.33.4 and helm v3.11.1 binaries (SHA256-verified)
- Enables Maren's `kubectl_get` and `helm_status` tools (previously stubs)

## Details

- UID/GID 65532 preserved — no Helm chart changes needed
- `curl` removed after binary install to minimise attack surface
- SHA256 checksums verified for both kubectl and helm downloads
- Version args (`KUBECTL_VERSION`, `HELM_VERSION`) for easy updates
- No Go code changes — `hasExec()` guard handles registration automatically
- All existing security (readOnlyRootFilesystem, capabilities drop, allowlist/denylist) unchanged

## Test plan

- [ ] CI passes (lint, tests, Docker build)
- [ ] `docker run --rm <image> kubectl version --client` succeeds
- [ ] `docker run --rm <image> helm version` succeeds
- [ ] Image size < 200MB
- [ ] Bridge logs show `maren: kubectl_get registered` (not stub)

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
