### PR TITLE
fix(orchestrator): 400 auto-recovery defence-in-depth 🐛

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -123,7 +123,7 @@ func (o *Orchestrator) handleWithDepth(ctx context.Context, roomID, userText, re
 		"history_turns", len(history)/2, "model", c.Model(),
 		"delegation_depth", depth)
 
-	result, err := o.runToolLoop(ctx, c, roomID, messages)
+	result, err := o.runToolLoop(ctx, c, roomID, buf, userMsg, messages)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -46,24 +46,40 @@ crew:
 `
 
 // mockClaudeClient supports multi-call sequences for tool-use testing.
+// Use callErrors (per-call) for recovery tests; use err (global) for
+// single-error-on-every-call tests.
 type mockClaudeClient struct {
-	responses []*anthropic.Message // returned in order; last one repeats if exhausted
-	err       error
-	calls     []anthropic.MessageNewParams
-	callIndex int
+	responses  []*anthropic.Message // returned in order; last one repeats if exhausted
+	err        error                // returned on every call (backward compat)
+	callErrors []error              // per-call errors; takes priority when non-nil slice
+	calls      []anthropic.MessageNewParams
+	callIndex  int
 }
 
 func (m *mockClaudeClient) New(_ context.Context, body anthropic.MessageNewParams, _ ...option.RequestOption) (*anthropic.Message, error) {
 	m.calls = append(m.calls, body)
-	if m.err != nil {
+	idx := m.callIndex
+
+	// Per-call errors take priority over the global err field.
+	if len(m.callErrors) > 0 {
+		errIdx := idx
+		if errIdx >= len(m.callErrors) {
+			errIdx = len(m.callErrors) - 1
+		}
+		if m.callErrors[errIdx] != nil {
+			m.callIndex++
+			return nil, m.callErrors[errIdx]
+		}
+	} else if m.err != nil {
 		return nil, m.err
 	}
-	idx := m.callIndex
-	if idx >= len(m.responses) {
-		idx = len(m.responses) - 1
+
+	respIdx := idx
+	if respIdx >= len(m.responses) {
+		respIdx = len(m.responses) - 1
 	}
 	m.callIndex++
-	return m.responses[idx], nil
+	return m.responses[respIdx], nil
 }
 
 func textResponse(text string) *anthropic.Message {
@@ -185,6 +201,16 @@ func newTestOrchestrator(t *testing.T, toolReg *tools.Registry, responses ...*an
 	}
 	mock := &mockClaudeClient{responses: responses}
 	return orchestrator.NewWithClient(reg, mgr, toolReg, mock), mock
+}
+
+// newTestOrchestratorWithMock is like newTestOrchestrator but uses a
+// pre-built mock — needed for recovery tests that configure per-call
+// errors via callErrors.
+func newTestOrchestratorWithMock(t *testing.T, toolReg *tools.Registry, mock *mockClaudeClient) *orchestrator.Orchestrator {
+	t.Helper()
+	reg := newTestRegistry(t)
+	mgr := ctxbuf.NewManager(ctxbuf.DefaultMaxTurns)
+	return orchestrator.NewWithClient(reg, mgr, toolReg, mock)
 }
 
 // =====================================================================
@@ -972,5 +998,109 @@ crew:
 	resultText := toolResult.Content[0].OfText.Text
 	if !strings.Contains(resultText, "context deadline exceeded") {
 		t.Errorf("expected 'context deadline exceeded' in result, got: %q", resultText)
+	}
+}
+
+// --- 400 auto-recovery tests (bridge#100) ---
+
+// orphanedToolResultError mimics the anthropic-sdk-go Error().
+// The real SDK error includes the HTTP method, URL, status code, and raw JSON
+// body. isOrphanedToolResultError matches on "400" + "unexpected tool_use_id".
+var orphanedToolResultError = fmt.Errorf(
+	`POST "https://api.anthropic.com/v1/messages": 400 Bad Request {"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.0: unexpected tool_use_id found in tool_result blocks: toolu_01ABC"}}`,
+)
+
+func TestHandle400OrphanedRetrySucceeds(t *testing.T) {
+	mock := &mockClaudeClient{
+		// Call 0: 400 orphaned tool_result error.
+		// Call 1 (retry): success text response.
+		callErrors: []error{orphanedToolResultError, nil},
+		responses:  []*anthropic.Message{textResponse("Recovered, Captain.")},
+	}
+	toolReg := tools.NewRegistry()
+	orch := newTestOrchestratorWithMock(t, toolReg, mock)
+
+	responses, err := orch.Handle(t.Context(), "!room:server", "hull check", "")
+	if err != nil {
+		t.Fatalf("expected recovery, got error: %v", err)
+	}
+	if len(responses) == 0 || responses[0].Text != "Recovered, Captain." {
+		t.Errorf("unexpected response: %+v", responses)
+	}
+	// Should have called the API exactly twice: initial (400) + retry (success).
+	if len(mock.calls) != 2 {
+		t.Errorf("expected 2 API calls (initial + retry), got %d", len(mock.calls))
+	}
+	// Retry should have only the fresh user message (buffer was cleared).
+	retryMsgs := mock.calls[1].Messages
+	if len(retryMsgs) != 1 {
+		t.Errorf("expected 1 message in retry (fresh user only), got %d", len(retryMsgs))
+	}
+}
+
+func TestHandle400DifferentErrorNoRetry(t *testing.T) {
+	differentError := fmt.Errorf(`POST "https://api.anthropic.com/v1/messages": 400 Bad Request {"type":"error","error":{"type":"invalid_request_error","message":"max_tokens must be positive"}}`)
+	mock := &mockClaudeClient{
+		err: differentError,
+	}
+	toolReg := tools.NewRegistry()
+	orch := newTestOrchestratorWithMock(t, toolReg, mock)
+
+	_, err := orch.Handle(t.Context(), "!room:server", "hull check", "")
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if !strings.Contains(err.Error(), "max_tokens") {
+		t.Errorf("expected original error, got: %v", err)
+	}
+	// Should have called exactly once — no retry.
+	if len(mock.calls) != 1 {
+		t.Errorf("expected 1 API call (no retry), got %d", len(mock.calls))
+	}
+}
+
+func TestHandle400OrphanedRetryAlsoFails(t *testing.T) {
+	mock := &mockClaudeClient{
+		// Both calls fail with the same orphaned error.
+		callErrors: []error{orphanedToolResultError, orphanedToolResultError},
+	}
+	toolReg := tools.NewRegistry()
+	orch := newTestOrchestratorWithMock(t, toolReg, mock)
+
+	_, err := orch.Handle(t.Context(), "!room:server", "hull check", "")
+	if err == nil {
+		t.Fatal("expected error after retry failure")
+	}
+	if !strings.Contains(err.Error(), "retry after buffer clear") {
+		t.Errorf("expected retry-failure error, got: %v", err)
+	}
+	// Two calls: initial + one retry.
+	if len(mock.calls) != 2 {
+		t.Errorf("expected 2 API calls, got %d", len(mock.calls))
+	}
+}
+
+func TestHandle400MidLoopNoRecovery(t *testing.T) {
+	// First call: tool_use response (iteration 0 succeeds).
+	// Second call: 400 orphaned error (iteration 1 — mid-loop).
+	// Mid-loop recovery is NOT attempted.
+	mock := &mockClaudeClient{
+		callErrors: []error{nil, orphanedToolResultError},
+		responses:  []*anthropic.Message{toolUseResponse("tu_1", "echo_tool", json.RawMessage(`{"msg":"hi"}`))},
+	}
+	toolReg := tools.NewRegistry()
+	toolReg.Register(&echoTool{})
+	orch := newTestOrchestratorWithMock(t, toolReg, mock)
+
+	_, err := orch.Handle(t.Context(), "!room:server", "hull check", "maren")
+	if err == nil {
+		t.Fatal("expected error from mid-loop 400")
+	}
+	if strings.Contains(err.Error(), "retry") {
+		t.Errorf("mid-loop 400 should NOT retry, got: %v", err)
+	}
+	// Two calls: iteration 0 (success) + iteration 1 (400, no retry).
+	if len(mock.calls) != 2 {
+		t.Errorf("expected 2 API calls, got %d", len(mock.calls))
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1003,10 +1003,10 @@ crew:
 
 // --- 400 auto-recovery tests (bridge#100) ---
 
-// orphanedToolResultError mimics the anthropic-sdk-go Error().
+// errOrphanedToolResult mimics the anthropic-sdk-go Error().
 // The real SDK error includes the HTTP method, URL, status code, and raw JSON
 // body. isOrphanedToolResultError matches on "400" + "unexpected tool_use_id".
-var orphanedToolResultError = fmt.Errorf(
+var errOrphanedToolResult = fmt.Errorf(
 	`POST "https://api.anthropic.com/v1/messages": 400 Bad Request {"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.0: unexpected tool_use_id found in tool_result blocks: toolu_01ABC"}}`,
 )
 
@@ -1014,7 +1014,7 @@ func TestHandle400OrphanedRetrySucceeds(t *testing.T) {
 	mock := &mockClaudeClient{
 		// Call 0: 400 orphaned tool_result error.
 		// Call 1 (retry): success text response.
-		callErrors: []error{orphanedToolResultError, nil},
+		callErrors: []error{errOrphanedToolResult, nil},
 		responses:  []*anthropic.Message{textResponse("Recovered, Captain.")},
 	}
 	toolReg := tools.NewRegistry()
@@ -1062,7 +1062,7 @@ func TestHandle400DifferentErrorNoRetry(t *testing.T) {
 func TestHandle400OrphanedRetryAlsoFails(t *testing.T) {
 	mock := &mockClaudeClient{
 		// Both calls fail with the same orphaned error.
-		callErrors: []error{orphanedToolResultError, orphanedToolResultError},
+		callErrors: []error{errOrphanedToolResult, errOrphanedToolResult},
 	}
 	toolReg := tools.NewRegistry()
 	orch := newTestOrchestratorWithMock(t, toolReg, mock)
@@ -1085,7 +1085,7 @@ func TestHandle400MidLoopNoRecovery(t *testing.T) {
 	// Second call: 400 orphaned error (iteration 1 — mid-loop).
 	// Mid-loop recovery is NOT attempted.
 	mock := &mockClaudeClient{
-		callErrors: []error{nil, orphanedToolResultError},
+		callErrors: []error{nil, errOrphanedToolResult},
 		responses:  []*anthropic.Message{toolUseResponse("tu_1", "echo_tool", json.RawMessage(`{"msg":"hi"}`))},
 	}
 	toolReg := tools.NewRegistry()

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -51,7 +51,7 @@ crew:
 type mockClaudeClient struct {
 	responses  []*anthropic.Message // returned in order; last one repeats if exhausted
 	err        error                // returned on every call (backward compat)
-	callErrors []error              // per-call errors; takes priority when non-nil slice
+	callErrors []error              // per-call errors; takes priority when non-empty
 	calls      []anthropic.MessageNewParams
 	callIndex  int
 }

--- a/internal/orchestrator/toolloop.go
+++ b/internal/orchestrator/toolloop.go
@@ -82,7 +82,6 @@ func (o *Orchestrator) runToolLoop(ctx context.Context, c crew.Crew, roomID stri
 					return nil, fmt.Errorf("anthropic api (retry after buffer clear): %w", retryErr)
 				}
 				resp = retryResp
-				err = nil
 			} else {
 				return nil, fmt.Errorf("anthropic api (iteration %d): %w", i, err)
 			}

--- a/internal/orchestrator/toolloop.go
+++ b/internal/orchestrator/toolloop.go
@@ -46,20 +46,22 @@ type loopResult struct {
 // once with only freshUserMsg. Mid-loop errors (iteration > 0) are NOT
 // retried because the in-flight state is complex.
 func (o *Orchestrator) runToolLoop(ctx context.Context, c crew.Crew, roomID string, buf *ctxbuf.ConversationBuffer, freshUserMsg anthropic.MessageParam, messages []anthropic.MessageParam) (*loopResult, error) {
-	crewTools := o.tools.ForCrew(c.Tools())
+	// Build params once — Messages is set per iteration (and swapped on retry).
+	// This prevents drift if new fields are added to the params struct later.
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(c.Model()),
+		MaxTokens: maxTokens,
+		System: []anthropic.TextBlockParam{
+			{Text: c.SystemPrompt()},
+		},
+		Tools: o.tools.ForCrew(c.Tools()),
+	}
 
 	var turns []anthropic.MessageParam
 
 	for i := range maxToolIterations {
-		resp, err := o.client.New(ctx, anthropic.MessageNewParams{
-			Model:     anthropic.Model(c.Model()),
-			MaxTokens: maxTokens,
-			System: []anthropic.TextBlockParam{
-				{Text: c.SystemPrompt()},
-			},
-			Messages: messages,
-			Tools:    crewTools,
-		})
+		params.Messages = messages
+		resp, err := o.client.New(ctx, params)
 		if err != nil {
 			// Defence-in-depth: on iteration 0, detect orphaned tool_result
 			// 400 and recover by clearing the buffer and retrying once.
@@ -68,16 +70,9 @@ func (o *Orchestrator) runToolLoop(ctx context.Context, c crew.Crew, roomID stri
 					"room", roomID, "crew", c.Name(), "err", err)
 				buf.Clear()
 				messages = []anthropic.MessageParam{freshUserMsg}
+				params.Messages = messages
 
-				retryResp, retryErr := o.client.New(ctx, anthropic.MessageNewParams{
-					Model:     anthropic.Model(c.Model()),
-					MaxTokens: maxTokens,
-					System: []anthropic.TextBlockParam{
-						{Text: c.SystemPrompt()},
-					},
-					Messages: messages,
-					Tools:    crewTools,
-				})
+				retryResp, retryErr := o.client.New(ctx, params)
 				if retryErr != nil {
 					return nil, fmt.Errorf("anthropic api (retry after buffer clear): %w", retryErr)
 				}

--- a/internal/orchestrator/toolloop.go
+++ b/internal/orchestrator/toolloop.go
@@ -8,6 +8,7 @@ import (
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 
+	ctxbuf "klazomenai/bridge/internal/context"
 	"klazomenai/bridge/internal/crew"
 	"klazomenai/bridge/internal/tools"
 )
@@ -38,7 +39,13 @@ type loopResult struct {
 // with tool_use blocks, the bridge executes the requested tools and feeds
 // results back. This continues until Claude produces a text response or the
 // iteration limit is reached.
-func (o *Orchestrator) runToolLoop(ctx context.Context, c crew.Crew, roomID string, messages []anthropic.MessageParam) (*loopResult, error) {
+//
+// Defence-in-depth (bridge#100): on iteration 0, if the API returns 400 with
+// "unexpected tool_use_id" (an orphaned tool_result left over from a prior
+// eviction — see bridge#99), the buffer is cleared and the request is retried
+// once with only freshUserMsg. Mid-loop errors (iteration > 0) are NOT
+// retried because the in-flight state is complex.
+func (o *Orchestrator) runToolLoop(ctx context.Context, c crew.Crew, roomID string, buf *ctxbuf.ConversationBuffer, freshUserMsg anthropic.MessageParam, messages []anthropic.MessageParam) (*loopResult, error) {
 	crewTools := o.tools.ForCrew(c.Tools())
 
 	var turns []anthropic.MessageParam
@@ -54,7 +61,31 @@ func (o *Orchestrator) runToolLoop(ctx context.Context, c crew.Crew, roomID stri
 			Tools:    crewTools,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("anthropic api (iteration %d): %w", i, err)
+			// Defence-in-depth: on iteration 0, detect orphaned tool_result
+			// 400 and recover by clearing the buffer and retrying once.
+			if i == 0 && isOrphanedToolResultError(err) {
+				slog.Warn("orchestrator: detected orphaned tool_result in buffer, clearing and retrying",
+					"room", roomID, "crew", c.Name(), "err", err)
+				buf.Clear()
+				messages = []anthropic.MessageParam{freshUserMsg}
+
+				retryResp, retryErr := o.client.New(ctx, anthropic.MessageNewParams{
+					Model:     anthropic.Model(c.Model()),
+					MaxTokens: maxTokens,
+					System: []anthropic.TextBlockParam{
+						{Text: c.SystemPrompt()},
+					},
+					Messages: messages,
+					Tools:    crewTools,
+				})
+				if retryErr != nil {
+					return nil, fmt.Errorf("anthropic api (retry after buffer clear): %w", retryErr)
+				}
+				resp = retryResp
+				err = nil
+			} else {
+				return nil, fmt.Errorf("anthropic api (iteration %d): %w", i, err)
+			}
 		}
 
 		// If Claude is done talking, extract text and return.
@@ -183,6 +214,19 @@ func buildResponse(c crew.Crew, text string) *Response {
 		CrewMember: c.Name(),
 		Verbosity:  c.Verbosity(),
 	}
+}
+
+// isOrphanedToolResultError detects the specific Anthropic API 400 error
+// caused by an orphaned tool_result block whose matching tool_use was evicted
+// from the conversation buffer. The anthropic-sdk-go error type lives in an
+// internal package (internal/apierror) so typed assertion is not possible;
+// we match on the Error() string which includes the status code and raw body.
+func isOrphanedToolResultError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "400") && strings.Contains(s, "unexpected tool_use_id")
 }
 
 // frameMessage caps and prefixes the user input to limit prompt injection surface.


### PR DESCRIPTION
## Summary

Defence-in-depth companion to PR #110 (bridge#99). If a malformed context buffer somehow reaches the Anthropic API despite the block-aware eviction fix, the 400 "unexpected tool_use_id" error is caught, the room buffer is cleared, and the request is retried once with only the fresh Captain input.

## Recovery logic

On iteration 0 of `runToolLoop`:

1. **Detect**: `isOrphanedToolResultError(err)` — string-matches `err.Error()` for "400" + "unexpected tool_use_id" (the anthropic-sdk-go error type is in `internal/apierror`, not importable for typed assertion)
2. **Clear**: `buf.Clear()` wipes the room's context buffer
3. **Rebuild**: messages = `[freshUserMsg]` — just the Captain's current input
4. **Retry once**: if retry also fails, propagate

**Mid-loop errors (iteration > 0) are NOT retried** — in-flight tool state is complex and recovery would risk inconsistency.

## Signature change

`runToolLoop(ctx, c, roomID, messages)` → `runToolLoop(ctx, c, roomID, buf, freshUserMsg, messages)`. The caller already had both in scope.

## Mock extension

`mockClaudeClient` gains a `callErrors []error` field for per-call error injection, taking priority over the global `err` field when populated. Existing tests unchanged.

## Tests (4 new)

| Test | Scenario | Expected |
|---|---|---|
| `TestHandle400OrphanedRetrySucceeds` | 400 on call 1, success on call 2 | Buffer cleared, retry delivers response |
| `TestHandle400DifferentErrorNoRetry` | 400 with "max_tokens" body | No retry, error propagates |
| `TestHandle400OrphanedRetryAlsoFails` | Both calls fail with marker | Exactly 1 retry, then propagation |
| `TestHandle400MidLoopNoRecovery` | 400 on iteration 2 (after tool round) | No retry on mid-loop |

**Orchestrator coverage**: 94.3% (up from ~85%).

Refs #100

## Test plan

- [x] `go test -tags goolm -count=1 ./internal/orchestrator/...` — pass
- [x] `go test -tags goolm -race ./internal/orchestrator/...` — clean
- [x] `go test -tags goolm -cover ./internal/orchestrator/...` — 94.3%
- [x] `go test -tags goolm -count=1 ./...` — full suite pass
- [x] `go vet -tags goolm ./...` — clean
- [x] Review + Copilot
- [x] Live verification deferred to batch release with #104/#105/#106/#107
