### PR TITLE
refactor(bot): extract ValidateAuthCrews from main.go 🧪

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -185,7 +186,12 @@ func main() {
 		os.Exit(1)
 	}
 	if err := bot.ValidateAuthCrews(userAuth, registry.IDs()); err != nil {
-		slog.Error("auth validation failed", "err", err)
+		var uce *bot.UnknownCrewError
+		if errors.As(err, &uce) {
+			slog.Error("auth config references unknown crew", "crew", uce.CrewID)
+		} else {
+			slog.Error("auth validation failed", "err", err)
+		}
 		os.Exit(1)
 	}
 

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -184,18 +184,9 @@ func main() {
 		slog.Error("failed to load auth config", "path", authPath, "err", err)
 		os.Exit(1)
 	}
-	if userAuth != nil {
-		knownCrew := registry.IDs()
-		knownSet := make(map[string]struct{}, len(knownCrew))
-		for _, c := range knownCrew {
-			knownSet[c] = struct{}{}
-		}
-		for _, c := range userAuth.CrewIDs() {
-			if _, ok := knownSet[c]; !ok {
-				slog.Error("auth config references unknown crew", "crew", c)
-				os.Exit(1)
-			}
-		}
+	if err := bot.ValidateAuthCrews(userAuth, registry.IDs()); err != nil {
+		slog.Error("auth validation failed", "err", err)
+		os.Exit(1)
 	}
 
 	// --- Session context manager ---

--- a/internal/bot/auth.go
+++ b/internal/bot/auth.go
@@ -101,10 +101,21 @@ func LoadAuth(path string) (*UserAuthorization, error) {
 	return auth, nil
 }
 
+// UnknownCrewError is returned by ValidateAuthCrews when the auth config
+// references a crew ID not present in the crew registry. Callers can use
+// errors.As to extract the CrewID for structured logging.
+type UnknownCrewError struct {
+	CrewID string
+}
+
+func (e *UnknownCrewError) Error() string {
+	return fmt.Sprintf("auth config references unknown crew: %q", e.CrewID)
+}
+
 // ValidateAuthCrews checks that every non-wildcard crew ID referenced in auth
-// exists in knownCrew. Returns an error naming the first unknown crew, or nil
-// if all are valid. When auth is nil, validation is skipped (no config = no
-// crew references to validate).
+// exists in knownCrew. Returns an *UnknownCrewError naming the first unknown
+// crew, or nil if all are valid. When auth is nil, validation is skipped (no
+// config = no crew references to validate).
 func ValidateAuthCrews(auth *UserAuthorization, knownCrew []string) error {
 	if auth == nil {
 		return nil
@@ -115,7 +126,7 @@ func ValidateAuthCrews(auth *UserAuthorization, knownCrew []string) error {
 	}
 	for _, c := range auth.CrewIDs() {
 		if _, ok := known[c]; !ok {
-			return fmt.Errorf("auth config references unknown crew: %q", c)
+			return &UnknownCrewError{CrewID: c}
 		}
 	}
 	return nil

--- a/internal/bot/auth.go
+++ b/internal/bot/auth.go
@@ -100,3 +100,23 @@ func LoadAuth(path string) (*UserAuthorization, error) {
 	}
 	return auth, nil
 }
+
+// ValidateAuthCrews checks that every non-wildcard crew ID referenced in auth
+// exists in knownCrew. Returns an error naming the first unknown crew, or nil
+// if all are valid. When auth is nil, validation is skipped (no config = no
+// crew references to validate).
+func ValidateAuthCrews(auth *UserAuthorization, knownCrew []string) error {
+	if auth == nil {
+		return nil
+	}
+	known := make(map[string]struct{}, len(knownCrew))
+	for _, c := range knownCrew {
+		known[c] = struct{}{}
+	}
+	for _, c := range auth.CrewIDs() {
+		if _, ok := known[c]; !ok {
+			return fmt.Errorf("auth config references unknown crew: %q", c)
+		}
+	}
+	return nil
+}

--- a/internal/bot/auth_test.go
+++ b/internal/bot/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"maunium.net/go/mautrix/id"
@@ -173,5 +174,35 @@ func TestLoadAuthInvalidYAML(t *testing.T) {
 	_, err := LoadAuth(path)
 	if err == nil {
 		t.Error("expected error for invalid YAML")
+	}
+}
+
+// --- ValidateAuthCrews tests (bridge#107) ---
+
+func TestValidateAuthCrews_Valid(t *testing.T) {
+	auth := &UserAuthorization{users: map[id.UserID]*crewPermission{
+		"@officer:server": {crew: map[string]struct{}{"maren": {}, "crest": {}}},
+	}}
+	if err := ValidateAuthCrews(auth, []string{"maren", "crest", "bosun"}); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateAuthCrews_UnknownCrew(t *testing.T) {
+	auth := &UserAuthorization{users: map[id.UserID]*crewPermission{
+		"@officer:server": {crew: map[string]struct{}{"maren": {}, "nonexistent": {}}},
+	}}
+	err := ValidateAuthCrews(auth, []string{"maren", "crest", "bosun"})
+	if err == nil {
+		t.Fatal("expected error for unknown crew")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("expected error to name the unknown crew, got: %v", err)
+	}
+}
+
+func TestValidateAuthCrews_NilAuth(t *testing.T) {
+	if err := ValidateAuthCrews(nil, []string{"maren", "crest"}); err != nil {
+		t.Errorf("expected no error for nil auth, got: %v", err)
 	}
 }

--- a/internal/bot/auth_test.go
+++ b/internal/bot/auth_test.go
@@ -1,10 +1,10 @@
 package bot
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"testing"
 
 	"maunium.net/go/mautrix/id"
@@ -196,8 +196,13 @@ func TestValidateAuthCrews_UnknownCrew(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown crew")
 	}
-	if !strings.Contains(err.Error(), "nonexistent") {
-		t.Errorf("expected error to name the unknown crew, got: %v", err)
+	// Verify the typed error exposes the crew ID for structured logging.
+	var uce *UnknownCrewError
+	if !errors.As(err, &uce) {
+		t.Fatalf("expected *UnknownCrewError, got %T", err)
+	}
+	if uce.CrewID != "nonexistent" {
+		t.Errorf("expected CrewID=nonexistent, got %q", uce.CrewID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Extracts the inline auth→crew validation logic from `cmd/bridge/main.go:187-198` into a testable function `bot.ValidateAuthCrews(auth, knownCrew)` in `internal/bot/auth.go`. The original code called `os.Exit(1)` directly, making the validation path untestable.

## Changes

- **`internal/bot/auth.go`**: new `ValidateAuthCrews(auth *UserAuthorization, knownCrew []string) error`
- **`internal/bot/auth_test.go`**: 3 new unit tests (valid, unknown crew, nil auth)
- **`cmd/bridge/main.go`**: inline validation block replaced with single function call

## Tests

| Test | Scenario | Expected |
|---|---|---|
| `TestValidateAuthCrews_Valid` | All crew IDs in auth exist in registry | nil error |
| `TestValidateAuthCrews_UnknownCrew` | Auth references "nonexistent" | error containing "nonexistent" |
| `TestValidateAuthCrews_NilAuth` | nil auth (no config) | nil error (skip validation) |

Refs #107

## Test plan

- [x] `go test -tags goolm -count=1 ./internal/bot/...` — pass
- [x] `go test -tags goolm -count=1 ./...` — full suite pass
- [x] `go vet -tags goolm ./...` — clean
- [x] Review + Copilot