### PR TITLE
fix(bot): suppress ERROR log on already-left disallowed room invite 🐛

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"go.mau.fi/util/dbutil"
 	_ "modernc.org/sqlite" // pure-Go SQLite driver, no CGo required
@@ -176,6 +177,22 @@ func (b *Bot) isRoomAllowed(roomID id.RoomID) bool {
 	return ok
 }
 
+// isAlreadyLeftError reports whether err is the homeserver's "cannot leave a
+// room you are not in" response, which fires when LeaveRoom is called for a
+// room the bot has already left (e.g. duplicate invite events from rapid
+// client clicks). Restricted to M_FORBIDDEN responses whose message indicates
+// the not-joined condition, so genuine forbidden errors continue to surface.
+func isAlreadyLeftError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if !errors.Is(err, mautrix.MForbidden) {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not joined") || strings.Contains(msg, "cannot leave")
+}
+
 // registerHandlers wires up event handlers on the syncer.
 func (b *Bot) registerHandlers() {
 	syncer := b.client.Syncer.(*mautrix.DefaultSyncer)
@@ -190,7 +207,11 @@ func (b *Bot) registerHandlers() {
 			member.Membership == event.MembershipInvite {
 			if !b.isRoomAllowed(evt.RoomID) {
 				if _, err := b.client.LeaveRoom(ctx, evt.RoomID); err != nil {
-					slog.Error("bot: failed to reject invite from disallowed room", "room", evt.RoomID, "err", err)
+					if isAlreadyLeftError(err) {
+						slog.Debug("bot: already left disallowed room", "room", evt.RoomID)
+					} else {
+						slog.Error("bot: failed to reject invite from disallowed room", "room", evt.RoomID, "err", err)
+					}
 				} else {
 					slog.Warn("bot: rejected invite from disallowed room", "room", evt.RoomID)
 				}

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -989,3 +989,78 @@ func TestTimeoutSendsGracefulMessage(t *testing.T) {
 		t.Error("typing should be cancelled after timeout")
 	}
 }
+
+// --- isAlreadyLeftError tests ---
+
+func TestIsAlreadyLeftErrorRespError(t *testing.T) {
+	// The exact server response from the issue: M_FORBIDDEN with the
+	// "cannot leave if not joined" message produced by Synapse-family
+	// homeservers when LeaveRoom is called for a room already left.
+	err := mautrix.RespError{
+		ErrCode: "M_FORBIDDEN",
+		Err:     "cannot leave if not joined, invited or knocked",
+	}
+	if !isAlreadyLeftError(err) {
+		t.Errorf("expected true for M_FORBIDDEN with 'cannot leave', got false")
+	}
+}
+
+func TestIsAlreadyLeftErrorWrappedHTTPError(t *testing.T) {
+	resp := mautrix.RespError{
+		ErrCode: "M_FORBIDDEN",
+		Err:     "cannot leave if not joined, invited or knocked",
+	}
+	httpErr := mautrix.HTTPError{
+		Response:  &http.Response{StatusCode: http.StatusForbidden},
+		RespError: &resp,
+	}
+	if !isAlreadyLeftError(httpErr) {
+		t.Errorf("expected true for HTTPError wrapping M_FORBIDDEN/cannot-leave, got false")
+	}
+}
+
+func TestIsAlreadyLeftErrorNotJoinedVariant(t *testing.T) {
+	// Defence against alternate phrasings from non-Synapse servers
+	// (e.g. Tuwunel/Conduit-family) — match on "not joined" too.
+	err := mautrix.RespError{
+		ErrCode: "M_FORBIDDEN",
+		Err:     "User is not joined to room",
+	}
+	if !isAlreadyLeftError(err) {
+		t.Errorf("expected true for M_FORBIDDEN with 'not joined', got false")
+	}
+}
+
+func TestIsAlreadyLeftErrorOtherForbidden(t *testing.T) {
+	// Other M_FORBIDDEN reasons (banned, no permission) must still surface
+	// as ERROR — only the already-left subcase is downgraded.
+	err := mautrix.RespError{
+		ErrCode: "M_FORBIDDEN",
+		Err:     "You are banned from this room",
+	}
+	if isAlreadyLeftError(err) {
+		t.Errorf("expected false for unrelated M_FORBIDDEN, got true")
+	}
+}
+
+func TestIsAlreadyLeftErrorNonForbidden(t *testing.T) {
+	err := mautrix.RespError{
+		ErrCode: "M_LIMIT_EXCEEDED",
+		Err:     "Too many requests",
+	}
+	if isAlreadyLeftError(err) {
+		t.Errorf("expected false for non-M_FORBIDDEN error, got true")
+	}
+}
+
+func TestIsAlreadyLeftErrorPlainError(t *testing.T) {
+	if isAlreadyLeftError(errors.New("network timeout")) {
+		t.Errorf("expected false for non-mautrix error, got true")
+	}
+}
+
+func TestIsAlreadyLeftErrorNil(t *testing.T) {
+	if isAlreadyLeftError(nil) {
+		t.Errorf("expected false for nil error, got true")
+	}
+}


### PR DESCRIPTION
## Summary

When the bridge receives multiple rapid invite events for the same disallowed room (e.g. a user clicks an invite several times in a Matrix client), `registerHandlers()`'s invite path fires once per event. The first `LeaveRoom` succeeds; subsequent calls return `M_FORBIDDEN (HTTP 403): cannot leave if not joined, invited or knocked` because the bridge has already left. The room is correctly rejected, but each duplicate produced an `ERROR` log line that could trigger false alerts in log-based monitoring.

## Changes

- **`internal/bot/bot.go`** — new `isAlreadyLeftError(err)` helper. Restricted to `mautrix.MForbidden` responses whose message (case-insensitive) contains `"cannot leave"` or `"not joined"`, so genuine forbidden errors (banned, no permission) keep surfacing as `ERROR`.
- **`internal/bot/bot.go`** — invite-rejection handler now downgrades the already-left subcase to `slog.Debug("bot: already left disallowed room", …)` and keeps `slog.Error` for everything else.
- **`internal/bot/bot_test.go`** — 7 unit tests covering both error shapes (`RespError`, `HTTPError` wrapping `RespError`), both phrasings (Synapse `"cannot leave …"` and Conduit-family `"not joined …"`), false-positive guards (other M_FORBIDDEN reasons, non-M_FORBIDDEN errors, plain errors, nil).

## Tests

| Test | Input | Expected |
|---|---|---|
| `TestIsAlreadyLeftErrorRespError` | `M_FORBIDDEN` + "cannot leave if not joined, invited or knocked" | `true` |
| `TestIsAlreadyLeftErrorWrappedHTTPError` | `HTTPError` wrapping the above | `true` |
| `TestIsAlreadyLeftErrorNotJoinedVariant` | `M_FORBIDDEN` + "User is not joined to room" | `true` |
| `TestIsAlreadyLeftErrorOtherForbidden` | `M_FORBIDDEN` + "You are banned from this room" | `false` |
| `TestIsAlreadyLeftErrorNonForbidden` | `M_LIMIT_EXCEEDED` | `false` |
| `TestIsAlreadyLeftErrorPlainError` | `errors.New("network timeout")` | `false` |
| `TestIsAlreadyLeftErrorNil` | `nil` | `false` |

Refs #105

## Test plan

- [x] `go test -tags goolm -count=1 ./internal/bot/...` — pass
- [x] `go test -tags goolm -count=1 ./...` — full suite pass
- [x] `go vet -tags goolm ./...` — clean
- [x] Review + Copilot
- [ ] Live: rapid-click invite from a disallowed room (or scripted: 3 invites in <1s); bridge logs show one `WARN bot: rejected invite from disallowed room` and one `DEBUG bot: already left disallowed room` (NOT a second `ERROR`)