### PR TITLE
test(testutil): adopt goleak + clockwork in shared testutil package 🧪

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -158,16 +158,18 @@ func TestFooTTL(t *testing.T) {
 
 - Unit tests should complete in **under 1 second** per package.
 - Integration tests (mock servers, lifecycle drivers) should complete in **under 5 seconds** per test.
-- Full suite (`go test ./...`) target: **under 90 seconds** including `-race`.
+- Full suite (`go test ./...`) target: **under 90 seconds** locally; CI is currently faster because it doesn't run `-race` (see below).
 
 If you find yourself adding a `time.Sleep` to make a test pass, you almost certainly want a fake clock instead.
 
 ## Race detection
 
-CI runs the suite under `-race`. Locally:
+CI today runs the suite **without** `-race` (see `.github/workflows/ci.yml`) — coverage is collected with `-covermode=atomic` instead. Adopting `-race` in CI is tracked under bridge#131 (test-runtime budget); the rough cost is ~2-3× wall-clock per package, which is the reason the work hasn't already landed.
+
+Until that lands, run `-race` locally before pushing any change that touches concurrent code:
 
 ```sh
 go test -tags goolm -race -count=1 ./...
 ```
 
-`-race` roughly triples test runtime; budget accordingly.
+The bridge has a small enough test surface that `-race` runs in a few seconds locally; there's no excuse to skip it on a concurrency-touching PR. CI failures from `-race`-only flakes will surface on the developer's laptop, not in production triage.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,9 +55,9 @@ Prefer per-test `IgnoreCurrent` over a `TestMain`-level `goleak.VerifyTestMain` 
 
   ```go
   func TestFoo(t *testing.T) {
-      defer testutil.VerifyNone(t) // runs LAST (deferred first → LIFO)
+      defer testutil.VerifyNone(t) // first defer statement; runs LAST
       srv := httptest.NewServer(handler)
-      defer srv.Close()            // runs FIRST (deferred second)
+      defer srv.Close()            // second defer statement; runs FIRST
       // ... test body ...
   }
   ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,11 @@ This document collects test-writing patterns shared across the codebase. New pat
 Tests that spawn goroutines should assert no goroutines escape the test boundary. Use `testutil.VerifyNone`:
 
 ```go
-import "klazomenai/bridge/internal/testutil"
+import (
+    "testing"
+
+    "klazomenai/bridge/internal/testutil"
+)
 
 func TestFoo(t *testing.T) {
     defer testutil.VerifyNone(t)
@@ -15,7 +19,7 @@ func TestFoo(t *testing.T) {
 }
 ```
 
-`VerifyNone` runs at test cleanup time. If any goroutine started during the test is still running when the test exits, the test fails with a goroutine dump pointing to the leak.
+`VerifyNone` runs via `defer` when the test function returns, before any `t.Cleanup` callbacks. If any goroutine started during the test is still running at that point, the test fails with a goroutine dump pointing to the leak. (See "Common false positives" below for why this ordering matters when servers and listeners are involved.)
 
 ### When to use
 
@@ -64,13 +68,18 @@ Prefer per-test `IgnoreCurrent` over a `TestMain`-level `goleak.VerifyTestMain` 
 Tests that assert time-dependent behaviour — TTL eviction, deadlines, retry backoff, periodic sweeps — must inject a clock interface and use a fake clock in tests. Real `time.Sleep` waits are a primary source of CI flake on slow runners.
 
 ```go
-import "klazomenai/bridge/internal/testutil"
+import (
+    "testing"
+    "time"
+
+    "klazomenai/bridge/internal/testutil"
+)
 
 func TestTTLEviction(t *testing.T) {
     defer testutil.VerifyNone(t)
     fc := testutil.NewFakeClock()
 
-    mgr := NewManagerWithClock(fc) // production constructor accepts testutil.Clock
+    mgr := NewManagerWithClock(fc) // production constructor accepts clockwork.Clock
 
     // ... add some entries ...
     fc.Advance(2 * time.Hour) // simulate two hours passing

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,7 +28,18 @@ func TestFoo(t *testing.T) {
 If a test runs in a binary where a prior test or `TestMain` started a long-lived goroutine (e.g. a package-level singleton), use `goleak.IgnoreCurrent()` to baseline:
 
 ```go
-defer testutil.VerifyNone(t, goleak.IgnoreCurrent())
+import (
+    "testing"
+
+    "go.uber.org/goleak"
+
+    "klazomenai/bridge/internal/testutil"
+)
+
+func TestFoo(t *testing.T) {
+    defer testutil.VerifyNone(t, goleak.IgnoreCurrent())
+    // ... test body ...
+}
 ```
 
 Prefer per-test `IgnoreCurrent` over a `TestMain`-level `goleak.VerifyTestMain` — the per-test scope keeps the leak surface tightest. Reach for `VerifyTestMain` only when an entire package's tests share the same baseline.
@@ -36,7 +47,16 @@ Prefer per-test `IgnoreCurrent` over a `TestMain`-level `goleak.VerifyTestMain` 
 ### Common false positives
 
 - The Go runtime's `sync.Pool` cleaner goroutine: handled automatically by `goleak`.
-- `httptest.Server` not closed: register `t.Cleanup(srv.Close)` immediately after creation.
+- `httptest.Server` not closed: call `defer srv.Close()` **after** the `defer testutil.VerifyNone(t)` line. Go runs deferred calls in LIFO order, so the server closes first and `VerifyNone` runs last — no false-positive listener-goroutine leak. (`t.Cleanup` callbacks run AFTER deferred calls and would arrive too late for the leak check.)
+
+  ```go
+  func TestFoo(t *testing.T) {
+      defer testutil.VerifyNone(t) // runs LAST (deferred first → LIFO)
+      srv := httptest.NewServer(handler)
+      defer srv.Close()            // runs FIRST (deferred second)
+      // ... test body ...
+  }
+  ```
 - Timer goroutines from `time.AfterFunc`: cancel the timer before test exit (`timer.Stop()`).
 
 ## Fake clocks (`clockwork`)
@@ -62,16 +82,62 @@ func TestTTLEviction(t *testing.T) {
 
 ### Production wiring
 
-Production constructors that need a clock should accept the `testutil.Clock` interface, not a concrete `*clockwork.FakeClock`. Pass `clockwork.NewRealClock()` from `main` (or wherever the production wiring lives):
+Production constructors that need a clock should accept the `clockwork.Clock` interface (which lives in `github.com/jonboulle/clockwork`, NOT in `internal/testutil` — production code must not import a test-only package). Pass `clockwork.NewRealClock()` from `cmd/bridge/main.go`; tests pass `testutil.NewFakeClock()`.
 
 ```go
 // internal/foo/foo.go
-import "klazomenai/bridge/internal/testutil"
+package foo
 
-func NewFoo(clk testutil.Clock) *Foo { ... }
+import (
+    "github.com/jonboulle/clockwork"
+)
 
+type Foo struct {
+    clk clockwork.Clock
+    // ...
+}
+
+func NewFoo(clk clockwork.Clock) *Foo {
+    return &Foo{clk: clk}
+}
+```
+
+```go
 // cmd/bridge/main.go
-foo := foo.NewFoo(clockwork.NewRealClock())
+package main
+
+import (
+    "github.com/jonboulle/clockwork"
+
+    "klazomenai/bridge/internal/foo"
+)
+
+func main() {
+    f := foo.NewFoo(clockwork.NewRealClock())
+    _ = f
+}
+```
+
+```go
+// internal/foo/foo_test.go
+package foo_test
+
+import (
+    "testing"
+    "time"
+
+    "klazomenai/bridge/internal/foo"
+    "klazomenai/bridge/internal/testutil"
+)
+
+func TestFooTTL(t *testing.T) {
+    defer testutil.VerifyNone(t)
+    fc := testutil.NewFakeClock()
+    f := foo.NewFoo(fc)
+    fc.Advance(2 * time.Hour)
+    // ... assert TTL behaviour ...
+    _ = f
+}
 ```
 
 ### When NOT to use a fake clock

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,98 @@
+# Testing patterns
+
+This document collects test-writing patterns shared across the codebase. New patterns land here when they're used by two or more packages.
+
+## Goroutine-leak verification (`goleak`)
+
+Tests that spawn goroutines should assert no goroutines escape the test boundary. Use `testutil.VerifyNone`:
+
+```go
+import "klazomenai/bridge/internal/testutil"
+
+func TestFoo(t *testing.T) {
+    defer testutil.VerifyNone(t)
+    // ... test body that spawns goroutines ...
+}
+```
+
+`VerifyNone` runs at test cleanup time. If any goroutine started during the test is still running when the test exits, the test fails with a goroutine dump pointing to the leak.
+
+### When to use
+
+- Any test that calls a function which `go func() { ... }()` is started inside.
+- Any test that uses a `*http.Server`, `net.Listener`, or other resource that spins its own goroutines.
+- Any test that uses `context.WithCancel` and expects cancellation to clean up downstream goroutines.
+
+### When to ignore current goroutines
+
+If a test runs in a binary where a prior test or `TestMain` started a long-lived goroutine (e.g. a package-level singleton), use `goleak.IgnoreCurrent()` to baseline:
+
+```go
+defer testutil.VerifyNone(t, goleak.IgnoreCurrent())
+```
+
+Prefer per-test `IgnoreCurrent` over a `TestMain`-level `goleak.VerifyTestMain` — the per-test scope keeps the leak surface tightest. Reach for `VerifyTestMain` only when an entire package's tests share the same baseline.
+
+### Common false positives
+
+- The Go runtime's `sync.Pool` cleaner goroutine: handled automatically by `goleak`.
+- `httptest.Server` not closed: register `t.Cleanup(srv.Close)` immediately after creation.
+- Timer goroutines from `time.AfterFunc`: cancel the timer before test exit (`timer.Stop()`).
+
+## Fake clocks (`clockwork`)
+
+Tests that assert time-dependent behaviour — TTL eviction, deadlines, retry backoff, periodic sweeps — must inject a clock interface and use a fake clock in tests. Real `time.Sleep` waits are a primary source of CI flake on slow runners.
+
+```go
+import "klazomenai/bridge/internal/testutil"
+
+func TestTTLEviction(t *testing.T) {
+    defer testutil.VerifyNone(t)
+    fc := testutil.NewFakeClock()
+
+    mgr := NewManagerWithClock(fc) // production constructor accepts testutil.Clock
+
+    // ... add some entries ...
+    fc.Advance(2 * time.Hour) // simulate two hours passing
+    mgr.Sweep()               // trigger TTL eviction explicitly
+
+    // ... assert eviction happened ...
+}
+```
+
+### Production wiring
+
+Production constructors that need a clock should accept the `testutil.Clock` interface, not a concrete `*clockwork.FakeClock`. Pass `clockwork.NewRealClock()` from `main` (or wherever the production wiring lives):
+
+```go
+// internal/foo/foo.go
+import "klazomenai/bridge/internal/testutil"
+
+func NewFoo(clk testutil.Clock) *Foo { ... }
+
+// cmd/bridge/main.go
+foo := foo.NewFoo(clockwork.NewRealClock())
+```
+
+### When NOT to use a fake clock
+
+- Tests that exercise real I/O timeouts where the system call's own timeout is the thing being tested. In those cases use `context.WithTimeout` and a tight bound (e.g. 100 ms).
+- Tests where wall-clock progression isn't load-bearing on the assertion. Prefer to remove the time dependency entirely.
+
+## Test budgets
+
+- Unit tests should complete in **under 1 second** per package.
+- Integration tests (mock servers, lifecycle drivers) should complete in **under 5 seconds** per test.
+- Full suite (`go test ./...`) target: **under 90 seconds** including `-race`.
+
+If you find yourself adding a `time.Sleep` to make a test pass, you almost certainly want a fake clock instead.
+
+## Race detection
+
+CI runs the suite under `-race`. Locally:
+
+```sh
+go test -tags goolm -race -count=1 ./...
+```
+
+`-race` roughly triples test runtime; budget accordingly.

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.25.0
 require (
 	github.com/anthropics/anthropic-sdk-go v1.27.1
 	github.com/emersion/go-imap/v2 v2.0.0-beta.8
+	github.com/jonboulle/clockwork v0.5.0
 	github.com/prometheus/prometheus v0.311.2
 	go.mau.fi/util v0.9.7
+	go.uber.org/goleak v1.3.0
 	gopkg.in/yaml.v3 v3.0.1
 	maunium.net/go/mautrix v0.26.4
 	modernc.org/sqlite v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853/go.mod h1:+JKpmjMGh
 github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -17,6 +17,7 @@ import (
 	ctxbuf "klazomenai/bridge/internal/context"
 	"klazomenai/bridge/internal/crew"
 	"klazomenai/bridge/internal/orchestrator"
+	"klazomenai/bridge/internal/testutil"
 	"klazomenai/bridge/internal/tools"
 )
 
@@ -218,6 +219,7 @@ func newTestOrchestratorWithMock(t *testing.T, toolReg *tools.Registry, mock *mo
 // =====================================================================
 
 func TestNewCreatesOrchestrator(t *testing.T) {
+	defer testutil.VerifyNone(t)
 	reg := newTestRegistry(t)
 	mgr := ctxbuf.NewManager(ctxbuf.DefaultMaxTurns)
 	toolReg := newToolRegistry()

--- a/internal/testutil/clock.go
+++ b/internal/testutil/clock.go
@@ -4,12 +4,6 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
-// Clock is the time interface tests inject in place of real wall time.
-// Production code that takes a Clock should accept the interface, not a
-// concrete clockwork type, so production wiring can pass clockwork.NewRealClock()
-// while tests pass NewFakeClock().
-type Clock = clockwork.Clock
-
 // NewFakeClock returns a *clockwork.FakeClock for use in tests.
 //
 // Use FakeClock for any test that asserts time-dependent behaviour —
@@ -17,8 +11,14 @@ type Clock = clockwork.Clock
 // with fc.Advance(d); never use real time.Sleep in tests, which is a
 // primary source of flake on slow CI runners.
 //
+// Production code that takes a clock should accept clockwork.Clock
+// directly (the interface lives in github.com/jonboulle/clockwork, not
+// here — internal/testutil is test-only). Production wiring passes
+// clockwork.NewRealClock() from cmd/bridge/main.go; tests pass the
+// *clockwork.FakeClock returned by this constructor.
+//
 //	fc := testutil.NewFakeClock()
-//	mgr := NewWithClock(fc) // production constructor takes testutil.Clock
+//	mgr := NewWithClock(fc) // production constructor takes clockwork.Clock
 //	fc.Advance(2 * time.Hour)
 //	// assert eviction happened
 func NewFakeClock() *clockwork.FakeClock {

--- a/internal/testutil/clock.go
+++ b/internal/testutil/clock.go
@@ -1,0 +1,26 @@
+package testutil
+
+import (
+	"github.com/jonboulle/clockwork"
+)
+
+// Clock is the time interface tests inject in place of real wall time.
+// Production code that takes a Clock should accept the interface, not a
+// concrete clockwork type, so production wiring can pass clockwork.NewRealClock()
+// while tests pass NewFakeClock().
+type Clock = clockwork.Clock
+
+// NewFakeClock returns a *clockwork.FakeClock for use in tests.
+//
+// Use FakeClock for any test that asserts time-dependent behaviour —
+// TTL eviction, deadlines, retry backoff. Advance the clock manually
+// with fc.Advance(d); never use real time.Sleep in tests, which is a
+// primary source of flake on slow CI runners.
+//
+//	fc := testutil.NewFakeClock()
+//	mgr := NewWithClock(fc) // production constructor takes testutil.Clock
+//	fc.Advance(2 * time.Hour)
+//	// assert eviction happened
+func NewFakeClock() *clockwork.FakeClock {
+	return clockwork.NewFakeClock()
+}

--- a/internal/testutil/clock.go
+++ b/internal/testutil/clock.go
@@ -13,9 +13,9 @@ import (
 //
 // Production code that takes a clock should accept clockwork.Clock
 // directly (the interface lives in github.com/jonboulle/clockwork, not
-// here — internal/testutil is test-only). Production wiring passes
-// clockwork.NewRealClock() from cmd/bridge/main.go; tests pass the
-// *clockwork.FakeClock returned by this constructor.
+// here — internal/testutil is test-only). Production wiring can pass
+// clockwork.NewRealClock(); tests pass the *clockwork.FakeClock returned
+// by this constructor.
 //
 //	fc := testutil.NewFakeClock()
 //	mgr := NewWithClock(fc) // production constructor takes clockwork.Clock

--- a/internal/testutil/doc.go
+++ b/internal/testutil/doc.go
@@ -1,0 +1,17 @@
+// Package testutil provides shared test helpers for the bridge codebase.
+//
+// Helpers landed here are reusable across packages so contributors do not
+// fork their own copies into per-package test files. Current scope:
+//
+//   - VerifyNone: wraps go.uber.org/goleak's goroutine-leak verification
+//     so tests can defer testutil.VerifyNone(t) without each adding the
+//     goleak import directly.
+//   - NewFakeClock: re-exports github.com/jonboulle/clockwork's fake clock
+//     for tests that exercise time-dependent code paths (TTL eviction,
+//     timeout handling, retry backoff). Avoids real time.Sleep waits which
+//     are a primary source of flake on slow CI runners.
+//
+// Add to this package when a helper would otherwise be duplicated across
+// two or more packages. Single-use helpers belong with the test that
+// uses them.
+package testutil

--- a/internal/testutil/goleak.go
+++ b/internal/testutil/goleak.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// VerifyNone fails the test if any goroutines have leaked beyond the
+// runtime baseline at the time VerifyNone is called.
+//
+// Typical usage at the top of a test that spawns goroutines:
+//
+//	func TestFoo(t *testing.T) {
+//	    defer testutil.VerifyNone(t)
+//	    // ... test body that spins up goroutines ...
+//	}
+//
+// Pass goleak.IgnoreCurrent() (or any other goleak.Option) when the test
+// needs to ignore goroutines that already exist before the test starts —
+// for example a package-level singleton spawned by a prior test in the
+// same binary. Ignoring per-test is preferred over ignoring per-package
+// (TestMain-level) because it keeps the leak surface smallest.
+func VerifyNone(t testing.TB, opts ...goleak.Option) {
+	t.Helper()
+	goleak.VerifyNone(t, opts...)
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,40 @@
+package testutil_test
+
+import (
+	"testing"
+	"time"
+
+	"klazomenai/bridge/internal/testutil"
+)
+
+// TestVerifyNone_NoLeaks confirms VerifyNone passes when no goroutines
+// were spawned by the test body.
+func TestVerifyNone_NoLeaks(t *testing.T) {
+	defer testutil.VerifyNone(t)
+	// no goroutines spawned; expect VerifyNone to succeed
+}
+
+// TestVerifyNone_CleanGoroutine confirms VerifyNone passes when a goroutine
+// is spawned but cleanly shuts down before VerifyNone is called.
+func TestVerifyNone_CleanGoroutine(t *testing.T) {
+	defer testutil.VerifyNone(t)
+	done := make(chan struct{})
+	go func() {
+		close(done)
+	}()
+	<-done
+}
+
+// TestNewFakeClock_AdvancesDeterministically confirms the fake clock advances
+// only when explicitly asked, never via real wall-clock progress.
+func TestNewFakeClock_AdvancesDeterministically(t *testing.T) {
+	defer testutil.VerifyNone(t)
+	fc := testutil.NewFakeClock()
+	start := fc.Now()
+
+	fc.Advance(2 * time.Hour)
+
+	if got := fc.Now().Sub(start); got != 2*time.Hour {
+		t.Errorf("expected 2h elapsed on fake clock, got %v", got)
+	}
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,6 +1,7 @@
 package testutil_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -15,14 +16,23 @@ func TestVerifyNone_NoLeaks(t *testing.T) {
 }
 
 // TestVerifyNone_CleanGoroutine confirms VerifyNone passes when a goroutine
-// is spawned but cleanly shuts down before VerifyNone is called.
+// is spawned but joins cleanly before VerifyNone is called.
+//
+// Uses sync.WaitGroup as the join mechanism (NOT a channel close) because
+// `wg.Done()` happens *after* the goroutine's body returns: by the time
+// `wg.Wait()` returns, the goroutine has fully exited, with no return-path
+// race window for goleak to observe. A channel close inside the goroutine
+// would only signal that the close call ran, not that the goroutine has
+// finished returning. This is the pattern downstream tests should model.
 func TestVerifyNone_CleanGoroutine(t *testing.T) {
 	defer testutil.VerifyNone(t)
-	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		close(done)
+		defer wg.Done()
+		// goroutine body — anything that completes
 	}()
-	<-done
+	wg.Wait()
 }
 
 // TestNewFakeClock_AdvancesDeterministically confirms the fake clock advances


### PR DESCRIPTION
## Summary

Lands `go.uber.org/goleak` and `github.com/jonboulle/clockwork` as direct dependencies and exposes them through a shared `internal/testutil` package. Tiny prep issue — three downstream M2 test issues (#86 lifecycle, #87 orchestrator integration, #88 concurrent isolation) and one observability fix (#91 LRU TTL eviction) each independently want one or both libraries; bundling adoption removes the dep-introduction negotiation from each downstream PR.

## Changes

| File | Purpose |
|---|---|
| `go.mod` / `go.sum` | Adds `go.uber.org/goleak v1.3.0` and `github.com/jonboulle/clockwork v0.5.0` as direct deps |
| `internal/testutil/doc.go` | Package-level Go-doc naming the package's intent (shared test helpers — slog capture, fake clocks, goleak verification, fixture loaders) so future contributors extend `testutil/` instead of forking helpers into per-package files |
| `internal/testutil/goleak.go` | `VerifyNone(t testing.TB, opts ...goleak.Option)` wraps `goleak.VerifyNone` so consumers can `defer testutil.VerifyNone(t)` without each adding the goleak import |
| `internal/testutil/clock.go` | `NewFakeClock()` constructor returning `*clockwork.FakeClock` (test-only convenience). Production code that needs a clock imports `github.com/jonboulle/clockwork` directly and accepts `clockwork.Clock` — `internal/testutil` is strictly test-only. |
| `internal/testutil/testutil_test.go` | 3 unit tests covering no-leak path, clean-goroutine-shutdown path, fake-clock-advance path |
| `internal/orchestrator/orchestrator_test.go` | `VerifyNone` wired into `TestNewCreatesOrchestrator` as the AC-mandated smoke check |
| `docs/testing.md` | New file documenting the patterns: when to use goleak, when to use `IgnoreCurrent`, common false positives, fake-clock production wiring, test-runtime budgets, race detection |

## Why

- **Three downstream issues independently want this**. Doing it once means three smaller PRs instead of three PRs each renegotiating dep adoption.
- **`goleak`** is the standard Go idiom for goroutine-leak testing. No reason to roll one.
- **`clockwork`** is the de-facto fake-clock library; tests that use real `time.Sleep` are a primary source of CI flake on slow runners.
- **Bundling**: pulling both deps in a single PR keeps `go.mod` churn down and avoids two separate dep-adoption review rounds.

## Tests

| Test | Asserts |
|---|---|
| `TestVerifyNone_NoLeaks` | No goroutines spawned → `VerifyNone` passes |
| `TestVerifyNone_CleanGoroutine` | Goroutine spawned, completes cleanly before `VerifyNone` → passes |
| `TestNewFakeClock_AdvancesDeterministically` | Fake clock advances only when explicitly told; no real wall-clock progression |

Plus `TestNewCreatesOrchestrator` now exercises `testutil.VerifyNone` as the integration smoke check, proving the package wiring works end-to-end before #86/#87/#88/#91 build on it.

## Test plan

- [x] `go test -tags goolm -count=1 ./internal/testutil/...` — pass
- [x] `go test -tags goolm -count=1 ./internal/orchestrator/...` — pass (smoke wiring confirmed)
- [x] `go test -tags goolm -count=1 ./...` — full suite green
- [x] `go vet -tags goolm ./...` — clean
- [x] Review + Copilot

Closes #126

