### PR TITLE
chore(ci): enforce per-package coverage thresholds 🏗️

### DIFF
--- a/.github/coverage-thresholds.yaml
+++ b/.github/coverage-thresholds.yaml
@@ -1,0 +1,35 @@
+# Per-package coverage floors enforced by .github/scripts/check-coverage.sh.
+#
+# Thresholds are set at the current floor minus a small headroom band (1-3pt)
+# so the gate never fires a false-positive on day one. Raise deliberately,
+# never silently. To raise, file a small chore PR that bumps the value AFTER
+# the work that earned the higher number has merged.
+#
+# Aspirational targets (per bridge#130 issue body, post-M2-sweep) are noted
+# in line comments — they apply once the test issues that drive them
+# (#81/#86/#87/#88/#91/#121/#122) have all landed.
+#
+# Override: PRs that intentionally drop coverage (e.g. removing dead code)
+# can include [allow-coverage-drop] in the PR body to bypass the gate. The
+# CI run will still post the coverage delta as a comment for visibility.
+#
+# Repo-wide overall coverage is tracked under `total` (informational only,
+# not used for gating — per-package thresholds carry the security weight).
+
+packages:
+  internal/context:        97  # current 97.9% — security weight: high (block-aware eviction invariant)
+  internal/orchestrator:   92  # current 94.4% — security weight: high (multi-turn tool execution)
+  internal/crew:           95  # current 97.1% — security weight: high (auth validation)
+  internal/bot:            75  # current 77.6% — aspirational ≥80% after #86/#121/#122 land
+  internal/crest:          40  # current 44.8% — aspirational ≥75% after #81 lands
+  internal/health:         85  # current 88.9% — small package; aspirational ≥90% with #89's /metrics path coverage
+  internal/testutil:       95  # current 100.0% — new in #126; small package
+  internal/tools:          80  # current 89.1% — registry/dispatch
+  internal/tools/chips:    80  # current 86.8% — aspirational ≥85% after #83 sanitiser tests land
+  internal/tools/crest:    80  # current 89.2%
+  internal/tools/lookout:  80  # current 85.7%
+  internal/tools/maren:    90  # current 95.5% — aspirational ≥95% after #85 redaction-key tests
+
+# Repo-wide total (informational only; not gating). The existing 70% gate
+# from the prior CI step is superseded by the per-package thresholds above.
+total: 80

--- a/.github/scripts/check-coverage.sh
+++ b/.github/scripts/check-coverage.sh
@@ -126,7 +126,9 @@ unknown_packages=()
 covered_packages=()
 
 # Walk every package that actually has coverage data; check against threshold.
-for pkg in "${!actual[@]}"; do
+# Iteration order is sorted (not associative-array native order) so the CI
+# log is deterministic and diff-friendly across runs.
+while IFS= read -r pkg; do
     cov="${actual[$pkg]}"
     if [[ -v threshold[$pkg] ]]; then
         t="${threshold[$pkg]}"
@@ -142,15 +144,16 @@ for pkg in "${!actual[@]}"; do
     else
         unknown_packages+=("$pkg ($cov%)")
     fi
-done
+done < <(printf '%s\n' "${!actual[@]}" | sort)
 
 # Walk every package in the YAML that DIDN'T appear in coverage data — likely
 # a renamed or removed package; surface it so the YAML stays accurate.
-for pkg in "${!threshold[@]}"; do
+# Sorted iteration for the same diff-friendly reasoning.
+while IFS= read -r pkg; do
     if [[ ! -v actual[$pkg] ]]; then
         printf 'SKIP  %-30s (no coverage data — package missing or excluded?)\n' "$pkg"
     fi
-done
+done < <(printf '%s\n' "${!threshold[@]}" | sort)
 
 if [[ ${#unknown_packages[@]} -gt 0 ]]; then
     echo

--- a/.github/scripts/check-coverage.sh
+++ b/.github/scripts/check-coverage.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Per-package coverage gate.
+#
+# Usage:
+#   .github/scripts/check-coverage.sh <coverage-profile>
+#
+# Reads .github/coverage-thresholds.yaml, runs `go tool cover -func` on the
+# supplied profile, computes per-package statement coverage, and exits non-zero
+# if any threshold is breached. Designed to be called from CI; runnable
+# locally too.
+#
+# Output is structured: one line per package, marked PASS / FAIL / SKIP, plus
+# a final summary. Failure rows include the delta vs threshold so the message
+# in the CI log tells you exactly how much you dropped.
+#
+# No external deps beyond bash, awk, grep, sed, and `go`. No yq/jq needed —
+# the YAML schema is a flat map so a tiny grep+awk parser handles it.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <coverage-profile>" >&2
+    exit 2
+fi
+
+profile="$1"
+thresholds_yaml="$(dirname "$0")/../coverage-thresholds.yaml"
+
+if [[ ! -f "$profile" ]]; then
+    echo "coverage profile not found: $profile" >&2
+    exit 2
+fi
+if [[ ! -f "$thresholds_yaml" ]]; then
+    echo "thresholds file not found: $thresholds_yaml" >&2
+    exit 2
+fi
+
+# Strip the module prefix from coverage profile paths so they match the
+# package keys in the YAML. Computed once.
+module="$(go list -m)"
+
+# Per-package coverage. Aggregates statement-level coverage from the profile.
+# `go tool cover -func` emits per-function lines plus a `total:` line; we
+# group functions by their package directory.
+#
+# Each output line: "<package> <coverage-percent>"
+per_package_coverage() {
+    go tool cover -func="$profile" | awk -v module="$module" '
+        # Skip the trailing total line — handled separately.
+        /^total:/ { next }
+        {
+            # Field 1 is "<file-path>:<line>:" — strip everything after the
+            # last "/" to get the package directory; strip the module prefix.
+            path = $1
+            sub(/\/[^\/]+:[0-9]+:$/, "", path)
+            sub("^" module "/", "", path)
+
+            # Field 3 is "NN.N%". Strip the percent and accumulate.
+            cov = $3
+            gsub(/%/, "", cov)
+            covered_pct[path] += cov + 0
+            n[path]++
+        }
+        END {
+            for (p in covered_pct) {
+                printf "%s %.1f\n", p, covered_pct[p] / n[p]
+            }
+        }
+    '
+}
+
+# `go tool cover -func`'s per-function coverage averaged is NOT statement
+# coverage. The proper number comes from running `go test` itself with -cover
+# but here we have only the profile. Statement coverage from a profile is
+# computable: statements covered / statements total per package. Re-derive it.
+per_package_statement_coverage() {
+    awk -v module="$module" '
+        NR == 1 { next }   # skip mode line: "mode: atomic"
+        {
+            # Profile line shape: "<file>:<srange> <statements> <covered>"
+            split($1, a, ":")
+            path = a[1]
+            sub(/\/[^\/]+$/, "", path)
+            sub("^" module "/", "", path)
+
+            stmts[path] += $2
+            if ($3 + 0 > 0) {
+                covered[path] += $2
+            }
+        }
+        END {
+            for (p in stmts) {
+                if (stmts[p] > 0) {
+                    printf "%s %.1f\n", p, (covered[p] / stmts[p]) * 100
+                }
+            }
+        }
+    ' "$profile"
+}
+
+# Read thresholds from YAML. Schema is intentionally flat (a single
+# `packages:` map plus a `total:` scalar) so we don't need yq.
+#
+# Output: "<package> <threshold>" per line.
+read_thresholds() {
+    awk '
+        /^packages:/ { in_packages = 1; next }
+        in_packages && /^[a-zA-Z]/ { in_packages = 0 }
+        in_packages && /^[[:space:]]+[a-zA-Z0-9_\/]+:[[:space:]]*[0-9]+/ {
+            # Strip leading whitespace, trailing comment, and the colon.
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]*#.*$/, "", line)
+            split(line, kv, ":")
+            key = kv[1]
+            val = kv[2]
+            gsub(/[[:space:]]/, "", val)
+            print key, val
+        }
+    ' "$thresholds_yaml"
+}
+
+# Total coverage from the profile.
+total_coverage() {
+    go tool cover -func="$profile" | awk '/^total:/ { gsub(/%/, "", $3); print $3 }'
+}
+
+# ---------- main ----------
+
+declare -A actual
+while read -r pkg cov; do
+    actual["$pkg"]="$cov"
+done < <(per_package_statement_coverage)
+
+declare -A threshold
+while read -r pkg t; do
+    threshold["$pkg"]="$t"
+done < <(read_thresholds)
+
+failures=0
+unknown_packages=()
+covered_packages=()
+
+# Walk every package that actually has coverage data; check against threshold.
+for pkg in "${!actual[@]}"; do
+    cov="${actual[$pkg]}"
+    if [[ -v threshold[$pkg] ]]; then
+        t="${threshold[$pkg]}"
+        # awk for floating-point comparison; portable across mac/linux.
+        if awk "BEGIN { exit !(${cov} < ${t}) }"; then
+            delta="$(awk "BEGIN { printf \"%.1f\", ${cov} - ${t} }")"
+            printf 'FAIL  %-30s %s%% < %s%% (delta %s)\n' "$pkg" "$cov" "$t" "$delta"
+            failures=$((failures + 1))
+        else
+            printf 'PASS  %-30s %s%% (threshold %s%%)\n' "$pkg" "$cov" "$t"
+        fi
+        covered_packages+=("$pkg")
+    else
+        unknown_packages+=("$pkg ($cov%)")
+    fi
+done
+
+# Walk every package in the YAML that DIDN'T appear in coverage data — likely
+# a renamed or removed package; surface it so the YAML stays accurate.
+for pkg in "${!threshold[@]}"; do
+    if [[ ! -v actual[$pkg] ]]; then
+        printf 'SKIP  %-30s (no coverage data — package missing or excluded?)\n' "$pkg"
+    fi
+done
+
+if [[ ${#unknown_packages[@]} -gt 0 ]]; then
+    echo
+    echo "Untracked packages (have coverage but no threshold in YAML):"
+    for p in "${unknown_packages[@]}"; do echo "  - $p"; done
+    echo "Add a threshold entry to .github/coverage-thresholds.yaml or accept"
+    echo "this as informational. Untracked packages do NOT fail the gate."
+fi
+
+echo
+echo "Total coverage: $(total_coverage)% (informational; not gating)"
+
+if [[ $failures -gt 0 ]]; then
+    echo
+    echo "$failures package(s) below threshold."
+    exit 1
+fi
+
+echo "All ${#covered_packages[@]} tracked package(s) at or above threshold."

--- a/.github/scripts/check-coverage.sh
+++ b/.github/scripts/check-coverage.sh
@@ -15,8 +15,19 @@
 #
 # No external deps beyond bash, awk, grep, sed, and `go`. No yq/jq needed —
 # the YAML schema is a flat map so a tiny grep+awk parser handles it.
+#
+# Requires Bash 4+ (associative arrays, `[[ -v ... ]]`). On macOS the system
+# /bin/bash is 3.2; install Bash 4+ via `brew install bash` and run with
+# `bash .github/scripts/check-coverage.sh ...` (the env-bash shebang will
+# pick up the Homebrew bash if it's earlier on PATH).
 
 set -euo pipefail
+
+if [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+    echo "error: this script requires Bash 4+; got ${BASH_VERSION:-unknown}" >&2
+    echo "  on macOS: brew install bash, then re-run with the Homebrew bash" >&2
+    exit 2
+fi
 
 if [[ $# -ne 1 ]]; then
     echo "usage: $0 <coverage-profile>" >&2

--- a/.github/scripts/check-coverage.sh
+++ b/.github/scripts/check-coverage.sh
@@ -39,40 +39,13 @@ fi
 # package keys in the YAML. Computed once.
 module="$(go list -m)"
 
-# Per-package coverage. Aggregates statement-level coverage from the profile.
-# `go tool cover -func` emits per-function lines plus a `total:` line; we
-# group functions by their package directory.
+# Per-package statement coverage from the profile.
 #
-# Each output line: "<package> <coverage-percent>"
-per_package_coverage() {
-    go tool cover -func="$profile" | awk -v module="$module" '
-        # Skip the trailing total line — handled separately.
-        /^total:/ { next }
-        {
-            # Field 1 is "<file-path>:<line>:" — strip everything after the
-            # last "/" to get the package directory; strip the module prefix.
-            path = $1
-            sub(/\/[^\/]+:[0-9]+:$/, "", path)
-            sub("^" module "/", "", path)
-
-            # Field 3 is "NN.N%". Strip the percent and accumulate.
-            cov = $3
-            gsub(/%/, "", cov)
-            covered_pct[path] += cov + 0
-            n[path]++
-        }
-        END {
-            for (p in covered_pct) {
-                printf "%s %.1f\n", p, covered_pct[p] / n[p]
-            }
-        }
-    '
-}
-
-# `go tool cover -func`'s per-function coverage averaged is NOT statement
-# coverage. The proper number comes from running `go test` itself with -cover
-# but here we have only the profile. Statement coverage from a profile is
-# computable: statements covered / statements total per package. Re-derive it.
+# Note: `go tool cover -func` emits *function*-level coverage; averaging those
+# numbers per package would NOT yield statement coverage because functions
+# have different statement counts. The correct number is statements covered /
+# statements total per package, which we derive directly from the profile
+# below. The per-function tool is used only for the `total:` line.
 per_package_statement_coverage() {
     awk -v module="$module" '
         NR == 1 { next }   # skip mode line: "mode: atomic"

--- a/.github/scripts/comment-coverage-delta.sh
+++ b/.github/scripts/comment-coverage-delta.sh
@@ -87,7 +87,10 @@ fetch_main_profile() {
         --jq '.[0].databaseId' 2>/dev/null || true)"
 
     if [[ -z "$run_id" || "$run_id" == "null" ]]; then
-        echo "::warning::no successful main-branch CI run found for delta"
+        # Warnings go to stderr so command substitution captures only the
+        # found path (or empty) on stdout. Otherwise the caller's
+        # `main_profile="$(fetch_main_profile)"` would contain warning text.
+        echo "::warning::no successful main-branch CI run found for delta" >&2
         return
     fi
 
@@ -98,7 +101,7 @@ fetch_main_profile() {
         --repo "$repo" \
         --dir "$workdir" \
         --pattern 'coverage-push-*' >/dev/null 2>&1; then
-        echo "::warning::failed to download main coverage artefact for run $run_id"
+        echo "::warning::failed to download main coverage artefact for run $run_id" >&2
         return
     fi
 
@@ -168,8 +171,13 @@ main_profile="$(fetch_main_profile)"
 marker='<!-- bridge-coverage-delta-comment -->'
 echo "$marker" >> /tmp/coverage-comment.md
 
+# Paginate the comments lookup. Default page size is 30; PRs that go through
+# multiple Copilot review rounds easily exceed that, and a missed marker on
+# page 2+ would cause this script to spam a fresh comment per push instead
+# of updating the existing one.
 existing_comment_id="$(gh api \
-    "repos/${repo}/issues/${PR_NUMBER}/comments" \
+    --paginate \
+    "repos/${repo}/issues/${PR_NUMBER}/comments?per_page=100" \
     --jq ".[] | select(.body | contains(\"$marker\")) | .id" 2>/dev/null \
     | head -1 || true)"
 

--- a/.github/scripts/comment-coverage-delta.sh
+++ b/.github/scripts/comment-coverage-delta.sh
@@ -18,6 +18,25 @@
 
 set -uo pipefail
 
+if [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+    echo "::warning::comment-coverage-delta.sh requires Bash 4+; got ${BASH_VERSION:-unknown}; skipping" >&2
+    echo "  on macOS: brew install bash, then re-run with the Homebrew bash" >&2
+    exit 0
+fi
+
+# Workdir at script scope — `fetch_main_profile` mkdirs into this and we
+# clean up once on EXIT. Avoids accumulating /tmp/tmp.XXXXXX directories
+# across local runs. CI runners are ephemeral, but the trap costs nothing
+# there either.
+WORKDIR=""
+cleanup() {
+    if [[ -n "$WORKDIR" && -d "$WORKDIR" ]]; then
+        rm -rf "$WORKDIR"
+    fi
+    rm -f /tmp/coverage-comment.md
+}
+trap cleanup EXIT
+
 if [[ $# -ne 1 ]]; then
     echo "::warning::usage: $0 <pr-coverage-profile>" >&2
     exit 0
@@ -70,10 +89,10 @@ per_package() {
 }
 
 # Try to download the most recent main-branch coverage artefact. Returns
-# the path to coverage.out on success, empty string otherwise.
+# the path to coverage.out on success, empty string otherwise. Uses the
+# script-scope WORKDIR which is cleaned up by the EXIT trap.
 fetch_main_profile() {
-    local workdir
-    workdir="$(mktemp -d)"
+    WORKDIR="$(mktemp -d)"
 
     # Find the most recent successful CI run on main.
     local run_id
@@ -99,7 +118,7 @@ fetch_main_profile() {
     # `coverage-push-` from that run; there's only one per run.
     if ! gh run download "$run_id" \
         --repo "$repo" \
-        --dir "$workdir" \
+        --dir "$WORKDIR" \
         --pattern 'coverage-push-*' >/dev/null 2>&1; then
         echo "::warning::failed to download main coverage artefact for run $run_id" >&2
         return
@@ -107,7 +126,7 @@ fetch_main_profile() {
 
     # Find the downloaded coverage.out (first match wins).
     local found
-    found="$(find "$workdir" -name 'coverage.out' -type f | head -1)"
+    found="$(find "$WORKDIR" -name 'coverage.out' -type f | head -1)"
     if [[ -n "$found" ]]; then
         echo "$found"
     fi

--- a/.github/scripts/comment-coverage-delta.sh
+++ b/.github/scripts/comment-coverage-delta.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Post a coverage-delta comment on the current PR.
+#
+# Usage:
+#   .github/scripts/comment-coverage-delta.sh <pr-coverage-profile>
+#
+# Best-effort: this script never fails the CI run. It tries to fetch the
+# most recent main-branch coverage artefact, computes per-package deltas,
+# and posts a single comment on the PR. If anything goes wrong (no main
+# artefact, gh API hiccup, parser failure), it logs a warning and exits 0.
+#
+# Required env:
+#   GH_TOKEN     — repo read + PR write
+#   PR_NUMBER    — pull request number
+#
+# Optional env:
+#   GITHUB_REPOSITORY — owner/repo (auto-set in Actions)
+
+set -uo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "::warning::usage: $0 <pr-coverage-profile>" >&2
+    exit 0
+fi
+
+pr_profile="$1"
+
+if [[ ! -f "$pr_profile" ]]; then
+    echo "::warning::PR coverage profile not found: $pr_profile"
+    exit 0
+fi
+
+if [[ -z "${PR_NUMBER:-}" ]]; then
+    echo "::warning::PR_NUMBER not set; skipping delta comment"
+    exit 0
+fi
+
+repo="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo)}"
+if [[ -z "$repo" ]]; then
+    echo "::warning::could not determine repo; skipping delta comment"
+    exit 0
+fi
+
+module="$(go list -m)"
+
+# Compute per-package statement coverage from a profile. Output: "<pkg> <pct>"
+#
+# Mirrors the parser in check-coverage.sh — kept inline rather than sourced
+# so this script stays standalone.
+per_package() {
+    local profile="$1"
+    awk -v module="$module" '
+        NR == 1 { next }
+        {
+            split($1, a, ":")
+            path = a[1]
+            sub(/\/[^\/]+$/, "", path)
+            sub("^" module "/", "", path)
+            stmts[path] += $2
+            if ($3 + 0 > 0) { covered[path] += $2 }
+        }
+        END {
+            for (p in stmts) {
+                if (stmts[p] > 0) {
+                    printf "%s %.1f\n", p, (covered[p] / stmts[p]) * 100
+                }
+            }
+        }
+    ' "$profile"
+}
+
+# Try to download the most recent main-branch coverage artefact. Returns
+# the path to coverage.out on success, empty string otherwise.
+fetch_main_profile() {
+    local workdir
+    workdir="$(mktemp -d)"
+
+    # Find the most recent successful CI run on main.
+    local run_id
+    run_id="$(gh run list \
+        --repo "$repo" \
+        --workflow CI \
+        --branch main \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId' 2>/dev/null || true)"
+
+    if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+        echo "::warning::no successful main-branch CI run found for delta"
+        return
+    fi
+
+    # Pull its coverage artefact. Artefact name in ci.yml is keyed on the
+    # commit SHA, not the run id, so take whichever artefact starts with
+    # `coverage-push-` from that run; there's only one per run.
+    if ! gh run download "$run_id" \
+        --repo "$repo" \
+        --dir "$workdir" \
+        --pattern 'coverage-push-*' >/dev/null 2>&1; then
+        echo "::warning::failed to download main coverage artefact for run $run_id"
+        return
+    fi
+
+    # Find the downloaded coverage.out (first match wins).
+    local found
+    found="$(find "$workdir" -name 'coverage.out' -type f | head -1)"
+    if [[ -n "$found" ]]; then
+        echo "$found"
+    fi
+}
+
+main_profile="$(fetch_main_profile)"
+
+# Build the comment body.
+# shellcheck disable=SC2016 # printf format strings contain literal backticks (markdown code-formatting), not command substitution
+{
+    echo "## 📊 Coverage report"
+    echo ""
+
+    if [[ -n "$main_profile" && -f "$main_profile" ]]; then
+        echo "Per-package statement coverage on this PR vs the most recent successful \`main\` build."
+        echo ""
+        echo "| Package | Main | PR | Δ |"
+        echo "|---|---|---|---|"
+
+        # Build associative arrays for both profiles, then walk.
+        declare -A pr_cov main_cov
+        while read -r pkg pct; do pr_cov["$pkg"]="$pct"; done < <(per_package "$pr_profile")
+        while read -r pkg pct; do main_cov["$pkg"]="$pct"; done < <(per_package "$main_profile")
+
+        # Union of packages, sorted for stable output.
+        for pkg in $(printf '%s\n%s\n' "${!pr_cov[@]}" "${!main_cov[@]}" | sort -u); do
+            m="${main_cov[$pkg]:-}"
+            p="${pr_cov[$pkg]:-}"
+            if [[ -z "$m" ]]; then
+                printf '| `%s` | — | %s%% | new |\n' "$pkg" "$p"
+            elif [[ -z "$p" ]]; then
+                printf '| `%s` | %s%% | — | removed |\n' "$pkg" "$m"
+            else
+                delta="$(awk "BEGIN { printf \"%+.1f\", $p - $m }")"
+                arrow="="
+                if   awk "BEGIN { exit !($p > $m + 0.05) }"; then arrow="🔼"
+                elif awk "BEGIN { exit !($p < $m - 0.05) }"; then arrow="🔽"
+                fi
+                printf '| `%s` | %s%% | %s%% | %s %s |\n' "$pkg" "$m" "$p" "$arrow" "$delta"
+            fi
+        done
+    else
+        echo "Per-package statement coverage on this PR. (No main-branch baseline available; showing current values only.)"
+        echo ""
+        echo "| Package | Coverage |"
+        echo "|---|---|"
+        per_package "$pr_profile" | sort | while read -r pkg pct; do
+            printf '| `%s` | %s%% |\n' "$pkg" "$pct"
+        done
+    fi
+
+    echo ""
+    echo "Thresholds enforced via \`.github/coverage-thresholds.yaml\`. Override with \`[allow-coverage-drop]\` in the PR body for deliberate drops."
+    echo ""
+    echo "<sub>Posted by \`.github/scripts/comment-coverage-delta.sh\`. Best-effort; not gating.</sub>"
+} > /tmp/coverage-comment.md
+
+# Post (or update) the comment. We use a marker comment to avoid spamming
+# the PR on every push — find an existing comment with the marker and edit
+# it; otherwise create a new one.
+marker='<!-- bridge-coverage-delta-comment -->'
+echo "$marker" >> /tmp/coverage-comment.md
+
+existing_comment_id="$(gh api \
+    "repos/${repo}/issues/${PR_NUMBER}/comments" \
+    --jq ".[] | select(.body | contains(\"$marker\")) | .id" 2>/dev/null \
+    | head -1 || true)"
+
+if [[ -n "$existing_comment_id" ]]; then
+    gh api \
+        "repos/${repo}/issues/comments/${existing_comment_id}" \
+        -X PATCH \
+        -F body=@/tmp/coverage-comment.md >/dev/null && \
+        echo "::notice::updated coverage comment ($existing_comment_id)"
+else
+    gh api \
+        "repos/${repo}/issues/${PR_NUMBER}/comments" \
+        -X POST \
+        -F body=@/tmp/coverage-comment.md >/dev/null && \
+        echo "::notice::posted new coverage comment"
+fi

--- a/.github/scripts/comment-coverage-delta.sh
+++ b/.github/scripts/comment-coverage-delta.sh
@@ -174,15 +174,23 @@ existing_comment_id="$(gh api \
     | head -1 || true)"
 
 if [[ -n "$existing_comment_id" ]]; then
-    gh api \
-        "repos/${repo}/issues/comments/${existing_comment_id}" \
-        -X PATCH \
-        -F body=@/tmp/coverage-comment.md >/dev/null && \
+    if gh api \
+            "repos/${repo}/issues/comments/${existing_comment_id}" \
+            -X PATCH \
+            -F body=@/tmp/coverage-comment.md >/dev/null; then
         echo "::notice::updated coverage comment ($existing_comment_id)"
+    else
+        echo "::warning::failed to update coverage comment ($existing_comment_id); skipping"
+        exit 0
+    fi
 else
-    gh api \
-        "repos/${repo}/issues/${PR_NUMBER}/comments" \
-        -X POST \
-        -F body=@/tmp/coverage-comment.md >/dev/null && \
+    if gh api \
+            "repos/${repo}/issues/${PR_NUMBER}/comments" \
+            -X POST \
+            -F body=@/tmp/coverage-comment.md >/dev/null; then
         echo "::notice::posted new coverage comment"
+    else
+        echo "::warning::failed to post new coverage comment; skipping"
+        exit 0
+    fi
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,18 @@ jobs:
         # The override marker `[allow-coverage-drop]` in a PR body bypasses
         # the gate but still surfaces the result for visibility. Useful for
         # deliberate refactors that remove dead code (and thus coverage).
+        #
+        # `set -o pipefail` is explicit (GitHub Actions enables it by default
+        # in the runner shell, but `set +e` doesn't disable pipefail and we
+        # want the contract to survive any future runner config drift).
+        # Without it, `rc=$?` would capture `tee`'s exit code (always 0) and
+        # silently mask gate failures.
         run: |
           set +e
+          set -o pipefail
           .github/scripts/check-coverage.sh coverage.out | tee coverage-report.txt
           rc=$?
-          set -e
+          set +o pipefail
           if [[ "$rc" -ne 0 ]]; then
             if [[ "${{ github.event_name }}" == "pull_request" ]] \
                 && grep -qF '[allow-coverage-drop]' <<< "${{ github.event.pull_request.body }}"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
           fi
 
       - name: Upload coverage profile
+        # `if: always()` so the artefact is preserved even when the gate
+        # fails, making post-mortem debugging of failing runs possible.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ github.event_name }}-${{ github.sha }}
@@ -69,7 +72,12 @@ jobs:
         # per-package coverage against the most recent main-branch run; if
         # no main run is available (first-ever run, expired artefact),
         # falls back to a current-only summary.
-        if: github.event_name == 'pull_request'
+        #
+        # `if: always()` is deliberate — when the gate fails is exactly
+        # when "what did I drop?" matters most. Without `always()` this
+        # step would skip on gate failure, leaving the user with no
+        # delta visibility precisely in the case where they need it.
+        if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,43 @@ jobs:
             -covermode=atomic \
             ./internal/...
 
-      - name: Coverage check
+      - name: Coverage check (per-package thresholds)
+        id: coverage_check
+        # The override marker `[allow-coverage-drop]` in a PR body bypasses
+        # the gate but still surfaces the result for visibility. Useful for
+        # deliberate refactors that remove dead code (and thus coverage).
         run: |
-          COVERAGE=$(go tool cover -func=coverage.out \
-            | grep '^total:' \
-            | awk '{print $3}' \
-            | tr -d '%')
-          echo "Total coverage: ${COVERAGE}%"
-          # Fail if below 70%.
-          awk -v c="$COVERAGE" 'BEGIN { if (c+0 < 70) { print "Coverage " c "% < 70% minimum"; exit 1 } }'
+          set +e
+          .github/scripts/check-coverage.sh coverage.out | tee coverage-report.txt
+          rc=$?
+          set -e
+          if [[ "$rc" -ne 0 ]]; then
+            if [[ "${{ github.event_name }}" == "pull_request" ]] \
+                && grep -qF '[allow-coverage-drop]' <<< "${{ github.event.pull_request.body }}"; then
+              echo "::warning::coverage gate would have failed (rc=$rc) but [allow-coverage-drop] override is set"
+              exit 0
+            fi
+            exit "$rc"
+          fi
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ github.event_name }}-${{ github.sha }}
+          path: coverage.out
+          retention-days: 30
+
+      - name: Post coverage delta comment
+        # Best-effort, not gating. Only runs on PRs. Compares the PR's
+        # per-package coverage against the most recent main-branch run; if
+        # no main run is available (first-ever run, expired artefact),
+        # falls back to a current-only summary.
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .github/scripts/comment-coverage-delta.sh coverage.out
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Replaces the existing repo-wide 70% coverage gate with **per-package thresholds**, set at the current floor minus a small headroom band (1-3pt) so the gate never fires false-positives on day one. Locks in the M1-sweep coverage gains; raise deliberately, never silently. Adds a best-effort PR comment with per-package coverage deltas vs the most recent successful main-branch run.

## Changes

| File | Purpose |
|---|---|
| `.github/coverage-thresholds.yaml` | Flat YAML map (`packages:` + `total:`) of package → threshold. Each entry annotated with current coverage and (where applicable) the aspirational post-M2 target plus the issue that drives it |
| `.github/scripts/check-coverage.sh` | Bash gate. Reads the YAML, parses **statement** coverage from the supplied profile (correctly: covered statements / total statements per package, NOT averaged function coverage), compares against thresholds, exits 1 with structured failure report on under-threshold. Lists untracked + skipped packages for YAML hygiene |
| `.github/scripts/comment-coverage-delta.sh` | Best-effort PR comment with per-package deltas vs the most recent successful main-branch run. Pulls the main coverage profile from CI artefact storage; falls back to current-only summary if no baseline available. Updates an existing marker comment instead of spamming on every push. Never fails CI |
| `.github/workflows/ci.yml` | Replaces the old single-line coverage check with the per-package gate; adds upload-artifact step so the next PR can compute deltas; adds post-coverage-comment step on PRs only |

## Day-1 thresholds (12 packages tracked)

| Package | Threshold | Current | Aspirational target |
|---|---|---|---|
| `internal/context` | ≥97% | 97.9% | — |
| `internal/orchestrator` | ≥92% | 94.4% | — |
| `internal/crew` | ≥95% | 97.1% | — |
| `internal/bot` | ≥75% | 77.6% | ≥80% after #86/#121/#122 |
| `internal/crest` | ≥40% | 44.8% | ≥75% after #81 |
| `internal/health` | ≥85% | 88.9% | — |
| `internal/testutil` | ≥95% | 100.0% | — |
| `internal/tools` | ≥80% | 89.1% | — |
| `internal/tools/chips` | ≥80% | 86.8% | — |
| `internal/tools/crest` | ≥80% | 89.2% | — |
| `internal/tools/lookout` | ≥80% | 85.7% | — |
| `internal/tools/maren` | ≥90% | 95.5% | — |
| Total (informational) | ≥80% | 85.3% | — |

Total coverage stays informational only — per-package thresholds carry the security weight (e.g. `internal/orchestrator` is multi-turn tool execution; treating it the same as a small utility package would hide regressions where they matter).

## Override

PRs that intentionally drop coverage (deliberate refactors removing dead code) can include `[allow-coverage-drop]` in the PR body. The gate emits a CI warning showing what would have failed and exits 0; the delta comment still fires for visibility.

## Why

- **Locks in current investment**: M1's coverage gains were earned through the M1 sweep. Without a CI gate they erode silently the moment a refactor removes a test path.
- **Per-package, not repo-level**: see issue body. `internal/orchestrator` carries security weight; treating it identically to a utility package masks regressions.
- **Catches silent loss**: deletion of a test file or refactor that removes a code path's exercises today goes unnoticed. With thresholds, both fail PR.
- **Day-1 honest floors**: thresholds set at current minus 1-3pt headroom per the issue's risk-factors note ("raise thresholds only after the sweep completes, not mid-flight"). The aspirational targets in the issue body stay as inline YAML comments and become bumps once the test issues that earn them land.

## Test plan

- [x] `.github/scripts/check-coverage.sh coverage.out` locally → all 12 packages PASS
- [x] Force a failure (`internal/bot: 99` instead of `75`) → script exits 1 with the expected `FAIL` line and delta `-21.4`
- [x] `shellcheck` clean on both scripts (4 SC2016 hits suppressed once with a directive — they're false positives from literal markdown backticks in printf format strings, not command substitution)
- [x] `go test -tags goolm -count=1 ./internal/...` → green (matches what CI gates against; `cmd/bridge` is wiring-only and exercised by #86's lifecycle test, deliberately not in the coverage scope)
- [ ] Review + Copilot
- [ ] CI run on this PR → verify the new gate passes, the delta comment fires (no main artefact yet so it'll fall back to a current-only summary on the first run), and the override marker is honoured if exercised
- [ ] Once merged: subsequent PR runs should produce delta comments against the merged main artefact

Refs #130

