### PR TITLE
chore(ci): scrub the deck — clear CI deprecation noise 🏗️

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Affected here: actions/checkout,
+# actions/setup-go, golangci/golangci-lint-action, actions/cache,
+# actions/upload-artifact. Drop this env once those bump to Node-24-native
+# versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,14 @@ permissions:
   pull-requests: write
   packages: write
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Affected here:
+# googleapis/release-please-action, actions/checkout, docker/setup-buildx-action,
+# docker/login-action, docker/build-push-action. Drop this env once those bump
+# to Node-24-native versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-please:
     name: Release Please


### PR DESCRIPTION
Routine deck-scrubbing. Clears the Node 20 deprecation warning from every Bridge CI run.

## What changed

- **`.github/workflows/ci.yml`**: added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow env level
- **`.github/workflows/release-please.yml`**: same

(Bridge doesn't use `DeterminateSystems/magic-nix-cache-action` — that part of the fleet-wide hygiene story doesn't apply here.)

## Why

Node 20 actions are forced to Node 24 starting 2026-06-02 and removed entirely 2026-09-16. The env var opts in early, future-safe, and drops cleanly when upstreams ship Node-24-native versions.

Affected actions (per workflow):
- `ci.yml` — actions/checkout, actions/setup-go, golangci/golangci-lint-action, actions/cache, actions/upload-artifact
- `release-please.yml` — googleapis/release-please-action, actions/checkout, docker/setup-buildx-action, docker/login-action, docker/build-push-action

All should work cleanly under Node 24.

## Local smoke-test

`actionlint` clean for these changes — three unrelated pre-existing warnings on lines this PR doesn't touch (out of scope).

## Acceptance criteria from #138

- [x] Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow env level on both `ci.yml` and `release-please.yml`
- [ ] CI run on the merge commit shows no Node 20 deprecation annotation *(verifiable post-merge — should change from "may not work as expected" to "are being forced to run on Node.js 24" informational, as observed on chart-house #5)*
- [ ] All three CI jobs still pass: `test`, `license-audit`, `docker` *(verifiable post-merge)*
- [ ] release-please workflow still functions *(verifiable on next release cycle)*
- [ ] No new failure-level annotations introduced *(verifiable post-merge)*

## Risk factors

- release-please flow downstream of CI — if env var breaks any action, release flow stalls. Verify on the merge commit that all jobs pass.
- License-audit job uses `go-licenses` installed at runtime via `setup-go`; should be unaffected by Node version changes.
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` is documented (GitHub blog post 2025-09-19). Safe default. If an action breaks under Node 24, drop the env var and stay on Node 20 until 2026-06-02, then revisit.

## Squash-commit subject

`chore(ci): scrub the deck — clear CI deprecation noise 🏗️`

Refs #138
