### PR TITLE
feat(crew): embed github skill into Chips system prompt 🎓

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,24 @@ diverge from the supported build path.
 
 CI will run the full test suite plus license-audit checks on every PR.
 
+### Re-syncing the Chips skill body
+
+Chips' system prompt is augmented at build time with a curated subset of the
+operator's `github` skill, vendored at `internal/crew/skills/github.md` and
+embedded via `go:embed`. To re-sync from a local dotfiles checkout:
+
+```bash
+cp ../dotfiles/claude/skills/github/SKILL.md internal/crew/skills/github.md
+# then hand-curate: strip the public-repo-sanitisation section, drop frontmatter,
+# leave the workflow rules. Diff before committing.
+```
+
+The sync is intentionally manual: the upstream skill targets human operators
+running Claude Code, and the embedded copy targets an autonomous orchestrator —
+sections need triage rather than blind copy. The
+`TestChipsSystemPromptContainsGitHubSkill` golden test catches accidental
+truncation.
+
 ## The Quartermaster's Conventions
 
 Where the rigging is dressed, every line in its place:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Aye, here's how we move the work from quayside to mast:
    Keeps everyone aligned on motivation, scope, and acceptance.
 2. **Branch off the trunk.** Name the branch
    `<type>/<issue-number>-<short-description>`. Types: `feat`, `fix`,
-   `chore`, `refactor`, `docs`, `ci`, `security`, `test`.
+   `chore`, `refactor`, `docs`, `ci`, `security`, `test`, `spike`.
 3. **Commit in conventional form.**
    [Conventional Commits](https://www.conventionalcommits.org/) — subject
    lines `<type>(scope): <description>`. Optional emoji at the **end** of

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -91,7 +91,11 @@ func Load(path string) (*Registry, error) {
 		}
 		prompt := strings.ReplaceAll(entry.SystemPrompt, "{verbosity}", verbDesc)
 		if id == "chips" {
-			prompt = prompt + "\n" + chipsGitHubSkill
+			// TrimRight bounds the separator on the prompt side: YAML `|`
+			// literal block scalars produce a trailing newline today, but
+			// `|-` would strip it. Normalising to exactly one blank line
+			// keeps the boundary stable regardless of YAML chomp style.
+			prompt = strings.TrimRight(prompt, "\n") + "\n\n" + chipsGitHubSkill
 		}
 		registry.crew[id] = &BaseCrew{
 			id:           id,

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -1,6 +1,7 @@
 package crew
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"sort"
@@ -8,6 +9,14 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+// chipsGitHubSkill is the curated github skill body, vendored from the operator's
+// dotfiles. Appended to Chips' system prompt at registry-load time so the persona
+// inherits the operator's standing rules on commits, branches, PRs, and review
+// threads. Re-sync via the command in CONTRIBUTING.md.
+//
+//go:embed skills/github.md
+var chipsGitHubSkill string
 
 // verbosityDescriptions maps verbosity mode names to their injected instruction text.
 var verbosityDescriptions = map[string]string{
@@ -81,6 +90,9 @@ func Load(path string) (*Registry, error) {
 			return nil, fmt.Errorf("crew %s: unknown verbosity %q", id, entry.Verbosity)
 		}
 		prompt := strings.ReplaceAll(entry.SystemPrompt, "{verbosity}", verbDesc)
+		if id == "chips" {
+			prompt = prompt + "\n" + chipsGitHubSkill
+		}
 		registry.crew[id] = &BaseCrew{
 			id:           id,
 			name:         entry.Name,

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -679,9 +679,9 @@ func TestChipsSystemPromptContainsGitHubSkill(t *testing.T) {
 		{"end-of-title emoji", "Emojis go at the END"},
 		{"copilot review workflow", "Copilot Review Workflow"},
 	}
-	for _, r := range requiredRules {
-		if !strings.Contains(prompt, r.fragment) {
-			t.Errorf("chips prompt missing %s rule: fragment %q not found", r.name, r.fragment)
+	for _, rule := range requiredRules {
+		if !strings.Contains(prompt, rule.fragment) {
+			t.Errorf("chips prompt missing %s rule: fragment %q not found", rule.name, rule.fragment)
 		}
 	}
 }

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -632,3 +632,85 @@ func TestRealCrewYAMLLoadsAndValidates(t *testing.T) {
 		t.Fatalf("real crew.yaml tool validation failed: %v", err)
 	}
 }
+
+// TestChipsSystemPromptContainsGitHubSkill verifies that the embedded github
+// skill body is appended to Chips' system prompt and that key rules survive
+// the build pipeline. Loads the real config/crew.yaml so a divergence between
+// the YAML prompt and the embedded skill is caught.
+func TestChipsSystemPromptContainsGitHubSkill(t *testing.T) {
+	const configPath = "../../config/crew.yaml"
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("config/crew.yaml not found at %s (running outside repo?)", configPath)
+	}
+
+	r, err := crew.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load real crew.yaml: %v", err)
+	}
+
+	chips := r.Get("chips")
+	if chips == nil {
+		t.Fatal("chips not found in real crew.yaml")
+	}
+
+	prompt := chips.SystemPrompt()
+
+	// Persona prompt itself must still be there (gate did not replace it).
+	if !strings.Contains(prompt, "Carpenter") {
+		t.Error("chips persona prompt missing — embedding overwrote rather than appended")
+	}
+
+	// Key skill rules that must survive build-time embedding. Each entry
+	// is a load-bearing rule; failure means the skill body was truncated,
+	// the gating logic dropped chips, or the source skill drifted away
+	// from the operator's standing instructions.
+	requiredRules := []struct {
+		name    string
+		fragment string
+	}{
+		{"signed commits", "--gpg-sign"},
+		{"refs not closes", "Refs #N"},
+		{"closes forbidden", "NEVER `Closes #N`"},
+		{"draft default", "ALWAYS create PRs as draft"},
+		{"never push main", "NEVER push to `main`"},
+		{"never amend", "NEVER amend commits"},
+		{"no auto-merge", "NEVER run `gh pr merge`"},
+		{"conventional commits", "Conventional commits format"},
+		{"end-of-title emoji", "Emojis go at the END"},
+		{"copilot review workflow", "Copilot Review Workflow"},
+	}
+	for _, r := range requiredRules {
+		if !strings.Contains(prompt, r.fragment) {
+			t.Errorf("chips prompt missing %s rule: fragment %q not found", r.name, r.fragment)
+		}
+	}
+}
+
+// TestNonChipsCrewLackGitHubSkill verifies the embedding is gated to chips —
+// Maren / Crest / Bosun / Lookout must not inherit GitHub workflow rules
+// they have no tools to act on.
+func TestNonChipsCrewLackGitHubSkill(t *testing.T) {
+	const configPath = "../../config/crew.yaml"
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("config/crew.yaml not found at %s (running outside repo?)", configPath)
+	}
+
+	r, err := crew.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load real crew.yaml: %v", err)
+	}
+
+	// Sentinel fragment unique to the embedded skill body.
+	const sentinel = "Copilot Review Workflow"
+
+	for _, id := range []string{"maren", "crest", "bosun", "lookout"} {
+		c := r.Get(id)
+		if c == nil {
+			t.Errorf("%s not found", id)
+			continue
+		}
+		if strings.Contains(c.SystemPrompt(), sentinel) {
+			t.Errorf("%s system prompt unexpectedly contains GitHub skill — gating broken", id)
+		}
+	}
+}

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -684,6 +684,15 @@ func TestChipsSystemPromptContainsGitHubSkill(t *testing.T) {
 			t.Errorf("chips prompt missing %s rule: fragment %q not found", rule.name, rule.fragment)
 		}
 	}
+
+	// Pin the persona ↔ skill boundary so a future edit to crew.yaml's
+	// scalar style (e.g. `|` → `|-`, which strips the trailing newline)
+	// or a skill-file rewrite that drops the leading header is caught
+	// at CI rather than only by visual inspection of the rendered prompt.
+	const boundary = "\n\n## Git + GitHub Workflow Rules"
+	if !strings.Contains(prompt, boundary) {
+		t.Errorf("chips prompt missing persona↔skill boundary %q — separator may have collapsed", boundary)
+	}
 }
 
 // TestNonChipsCrewLackGitHubSkill verifies the embedding is gated to chips —

--- a/internal/crew/skills/github.md
+++ b/internal/crew/skills/github.md
@@ -1,0 +1,104 @@
+## Git + GitHub Workflow Rules
+
+These rules apply when you work on git history, GitHub issues, pull requests, or
+review threads. They are vendored from the operator's `github` skill — keep them
+in sync (see CONTRIBUTING.md `sync-skills` note).
+
+### Commits
+
+- Conventional commits format: `<type>(scope): description`
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `perf`, `security`
+- Signed commits required: `git commit --gpg-sign`
+- Use `Refs #N` in commit body — NEVER `Closes #N`, `Fixes #N`, or `Resolves #N`.
+  Closing an issue is a merge-time decision, not yours.
+- NO Claude co-author line on private repos. Check visibility with
+  `gh repo view --json isPrivate -q '.isPrivate'` before committing.
+- NEVER amend commits or force-push. Stack separate signed commits; squash on merge.
+- Commit-message emoji prefixes (in the message body, not in branch names):
+  ✨ feat | 🐛 fix | 📝 docs | ♻️ refactor | 🧪 test | ⚙️ chore | 🔐 security | 🏗️ ci | ⚡ perf
+
+### Branches
+
+- NEVER push to `main` or the default branch — NO EXCEPTIONS.
+- NEVER create a `master` branch.
+- Naming: `<type>/<issue>-<description>` e.g. `feat/595-jaeger-tracing`,
+  `fix/784-terraform-exit-code`.
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `security`, `spike`.
+- Base branch: `main`. Merge style: squash merge. Delete branch after merge.
+- No emojis in branch names.
+
+### Pull Requests
+
+- ALWAYS create PRs as draft: `gh pr create --draft`.
+- After creating a PR, STOP. Provide the PR URL. Do NOT suggest merging or next steps.
+- NEVER run `gh pr merge` or `gh pr ready` — merging is a human decision.
+- CI passing does NOT mean ready to merge.
+- Conventional commit format for PR titles. Title emojis go at the END.
+- PR body format:
+
+  ```
+  ## Summary
+  <1-3 bullet points>
+
+  ## Test plan
+  - [ ] Bulleted checklist of testing TODOs
+  ```
+
+- Use temp files for PR bodies to avoid hook false positives:
+  write the body to a file, then pass `-F "body=@file"`.
+
+### Issues
+
+- Conventional prefix on issue titles: `feat:`, `fix:`, `chore:`, etc.
+- Emojis go at the END of issue titles.
+- Type emojis: 🐙 Epic | 🔍 Spike | 📊 Dashboard | 🔔 Alert | 🚪 Gateway | 🔐 Security | 🪦 Decommission
+- Status emojis: ✅ Done | ❌ Blocked | ⏸️ Paused | 🚧 WIP | 📋 Planned
+
+### Labels
+
+- Standard: `epic`, `spike`, `bug`, `enhancement`, `refactor`, `techdebt`
+- Namespaced: `app:*`, `env:*`, `fun:*`, `ws:*`, `depth:*`, `priority:*`, `provider:*`
+
+### Copilot Review Workflow
+
+When handling Copilot PR review comments:
+
+1. **Read** — `gh api repos/{owner}/{repo}/pulls/{pr}/comments`, filter top-level
+   only (where `in_reply_to_id` is null).
+2. **Discuss** — present each comment with assessment (agree/disagree/partial),
+   explain reasoning with technical justification.
+3. **User decides** — wait for explicit confirmation on which comments to address.
+4. **Fix locally** — make the code changes.
+5. **Test locally before pushing** — run changed code from working tree.
+6. **Commit and push** — new commit on same branch (never amend).
+7. **Reply inline** — write reply body to temp file, then
+   `gh api repos/{owner}/{repo}/pulls/{pr}/comments -X POST -F "body=@$tmpfile" -F in_reply_to=<id>`,
+   reference the fix commit SHA.
+
+Rules:
+
+- Push back on wrong suggestions with technical reasoning — not every comment is correct.
+- Reply to EVERY top-level comment, even when disagreeing.
+- Reference the fix commit SHA in replies where changes were made.
+
+### File Hygiene
+
+- Newlines at EOF.
+- No trailing whitespace.
+- LF line endings (no CRLF).
+- Never commit secrets (`.env`, credentials, keys, tokens).
+- Never commit `.terraform/`, `.tfstate`, `node_modules/`, or other generated artifacts.
+
+### Anti-Patterns to Refuse
+
+- Pushing directly to `main` or the default branch.
+- Creating `master` branches.
+- Using `Closes #N`, `Fixes #N`, or `Resolves #N` in commit messages.
+- Adding Claude co-author to private-repo commits.
+- Using `gh pr merge` or `gh pr ready` (merging is a human decision).
+- Creating non-draft PRs.
+- Committing secrets or credentials.
+- Using `gh repo create --push` (pushes to main).
+- Amending commits during PR review (`--amend`) — stack new signed commits instead.
+- Force-pushing (`--force`, `--force-with-lease`).
+- Emojis in branch names or code.

--- a/internal/crew/skills/github.md
+++ b/internal/crew/skills/github.md
@@ -44,8 +44,10 @@ in sync (see "Re-syncing the Chips skill body" in CONTRIBUTING.md).
   - [ ] Bulleted checklist of testing TODOs
   ```
 
-- Use temp files for PR bodies to avoid hook false positives:
-  write the body to a file, then pass `-F "body=@file"`.
+- Use temp files for PR bodies to avoid hook false positives: write the body
+  to a file, then `gh pr create --body-file path/to/file --draft ...`. Note
+  that `--body-file <path>` is the `gh pr create` flag; the `-F body=@file`
+  form-field syntax is for `gh api` calls only — see PR Review Replies below.
 
 ### Issues
 

--- a/internal/crew/skills/github.md
+++ b/internal/crew/skills/github.md
@@ -2,7 +2,7 @@
 
 These rules apply when you work on git history, GitHub issues, pull requests, or
 review threads. They are vendored from the operator's `github` skill — keep them
-in sync (see CONTRIBUTING.md `sync-skills` note).
+in sync (see "Re-syncing the Chips skill body" in CONTRIBUTING.md).
 
 ### Commits
 


### PR DESCRIPTION
## Summary

- Vendors a curated `github` skill at `internal/crew/skills/github.md` and appends it to Chips' system prompt via `go:embed`. Gated on `id == "chips"` so other crew are unaffected.
- Adds two tests against the real `config/crew.yaml`: one asserts Chips' rendered prompt carries the load-bearing rules (signed commits, `Refs #N`, draft-PR default, no auto-merge, no amend, conventional commits, end-of-title emoji, Copilot review workflow); the other verifies the embedding is gated and does not leak into Maren / Crest / Bosun / Lookout.
- Documents the manual re-sync command in `CONTRIBUTING.md` — sync is intentionally curated rather than automated because the upstream skill targets human Claude Code users while Chips is autonomous; sections need triage. A `Makefile` sync target was scoped out of this PR (no Makefile in repo today; can be a future follow-up).

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./...` — clean
- [x] `CGO_ENABLED=0 go test -tags goolm ./internal/...` — all packages pass including the two new tests
- [x] `CGO_ENABLED=0 go build -tags goolm ./cmd/bridge` — builds
- [x] Manual: `git log --show-signature` confirms signed commit
- [ ] Reviewer to spot-check that the curated skill at `internal/crew/skills/github.md` keeps the rules a Chips invocation actually needs (commits, branches, PRs, Copilot review) and drops what it doesn't (public-repo sanitisation — not applicable to in-tool generation)

Refs #143
