### PR TITLE
feat(crew): introduce Source/Compose API for skill composition 🎓

### DIFF
--- a/internal/crew/skills/compose.go
+++ b/internal/crew/skills/compose.go
@@ -45,9 +45,9 @@ func Compose(persona string, skills []string, src Source) (string, error) {
 	}
 	// Reject nil src up front, regardless of skills emptiness, so the
 	// API contract is "src must be non-nil" rather than the conditional
-	// "src may be nil iff skills is empty". Fails fast and caller
-	// misconfiguration cannot reach the deref path below.
-	if src == nil {
+	// "src may be nil iff skills is empty". isNilSource also catches
+	// the typed-nil-in-interface case which `== nil` would miss.
+	if isNilSource(src) {
 		return "", ErrNilSource
 	}
 

--- a/internal/crew/skills/compose.go
+++ b/internal/crew/skills/compose.go
@@ -54,7 +54,10 @@ func Compose(persona string, skills []string, src Source) (string, error) {
 	universal, err := src.Universal()
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return "", fmt.Errorf("%w: %v", ErrUniversalRequired, err)
+			// Multi-%w preserves both sentinels in the wrap chain so
+			// callers can match either with errors.Is — required by
+			// the doc contract on ErrUniversalRequired.
+			return "", fmt.Errorf("%w: %w", ErrUniversalRequired, err)
 		}
 		return "", fmt.Errorf("compose: load universal: %w", err)
 	}

--- a/internal/crew/skills/compose.go
+++ b/internal/crew/skills/compose.go
@@ -1,0 +1,95 @@
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+var (
+	// ErrEmptyPersona is returned by Compose when the persona argument
+	// is empty.
+	ErrEmptyPersona = errors.New("compose: empty persona")
+	// ErrUniversalRequired is returned by Compose (wrapped around the
+	// underlying ErrNotFound) when the universal addendum cannot be
+	// loaded but the calling crew has declared at least one skill.
+	ErrUniversalRequired = errors.New("compose: universal addendum required when skills declared")
+)
+
+// Compose renders the persona system prompt augmented with the universal
+// addendum, the per-skill SKILL.md, and (where present) the per-skill
+// profile addendum.
+//
+// When skills is empty, returns the persona unchanged (no universal
+// section). When skills contains at least one entry:
+//   - Universal addendum is required (ErrUniversalRequired if missing)
+//   - Each skill's SKILL.md is required (wrapped error if missing)
+//   - Per-skill profile addendums are optional (silently skipped on
+//     ErrNotFound)
+//
+// Output format: persona, then a sequence of "## <Heading>" sections
+// separated by exactly one blank line. Section headings:
+//   - "## Operator Universal Rules"
+//   - "## <Skill> Workflow Rules" (per skill, in declaration order)
+//   - "## <Skill> Profile Addendum" (per skill with profile, in
+//     declaration order)
+//
+// Skill heading title-casing is via a simple first-rune uppercase (so
+// "github" → "Github"). Proper-noun casing (e.g. "GitHub") is deferred
+// to a future SkillMetadata{DisplayName} field — accepted cosmetic
+// regression in #148, see plan decisions.
+func Compose(persona string, skills []string, src Source) (string, error) {
+	if persona == "" {
+		return "", ErrEmptyPersona
+	}
+
+	if len(skills) == 0 {
+		return persona, nil
+	}
+
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(persona, "\n"))
+
+	universal, err := src.Universal()
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return "", fmt.Errorf("%w: %v", ErrUniversalRequired, err)
+		}
+		return "", fmt.Errorf("compose: load universal: %w", err)
+	}
+	b.WriteString("\n\n## Operator Universal Rules\n\n")
+	b.WriteString(strings.TrimSpace(universal.Content))
+
+	for _, name := range skills {
+		skill, err := src.Skill(name)
+		if err != nil {
+			return "", fmt.Errorf("compose: load skill %q: %w", name, err)
+		}
+		fmt.Fprintf(&b, "\n\n## %s Workflow Rules\n\n", titleCase(name))
+		b.WriteString(strings.TrimSpace(skill.Content))
+
+		profile, err := src.Profile(name)
+		if errors.Is(err, ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("compose: load profile %q: %w", name, err)
+		}
+		fmt.Fprintf(&b, "\n\n## %s Profile Addendum\n\n", titleCase(name))
+		b.WriteString(strings.TrimSpace(profile.Content))
+	}
+
+	return b.String(), nil
+}
+
+// titleCase converts "github" → "Github". Proper-noun overrides
+// (e.g. "GitHub") deferred to a future SkillMetadata field.
+func titleCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
+}

--- a/internal/crew/skills/compose.go
+++ b/internal/crew/skills/compose.go
@@ -43,6 +43,13 @@ func Compose(persona string, skills []string, src Source) (string, error) {
 	if persona == "" {
 		return "", ErrEmptyPersona
 	}
+	// Reject nil src up front, regardless of skills emptiness, so the
+	// API contract is "src must be non-nil" rather than the conditional
+	// "src may be nil iff skills is empty". Fails fast and caller
+	// misconfiguration cannot reach the deref path below.
+	if src == nil {
+		return "", ErrNilSource
+	}
 
 	if len(skills) == 0 {
 		return persona, nil

--- a/internal/crew/skills/compose_test.go
+++ b/internal/crew/skills/compose_test.go
@@ -16,6 +16,29 @@ func TestComposeEmptyPersonaReturnsError(t *testing.T) {
 	}
 }
 
+func TestComposeNilSourceReturnsError(t *testing.T) {
+	// Nil src must surface as ErrNilSource for ANY skills shape, even
+	// empty — the contract is "src must be non-nil", not the
+	// conditional "src may be nil iff skills is empty". This prevents
+	// caller misconfiguration from reaching the deref path inside the
+	// loop below.
+	cases := []struct {
+		name   string
+		skills []string
+	}{
+		{"empty skills", nil},
+		{"non-empty skills", []string{"github"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := skills.Compose("PERSONA", tc.skills, nil)
+			if !errors.Is(err, skills.ErrNilSource) {
+				t.Errorf("expected ErrNilSource, got %v", err)
+			}
+		})
+	}
+}
+
 func TestComposeNoSkillsReturnsPersonaUnchanged(t *testing.T) {
 	src := MapSource{
 		"_universal.md": "should not appear when skills is empty",

--- a/internal/crew/skills/compose_test.go
+++ b/internal/crew/skills/compose_test.go
@@ -101,6 +101,12 @@ func TestComposeMissingUniversalIsError(t *testing.T) {
 	if !errors.Is(err, skills.ErrUniversalRequired) {
 		t.Errorf("expected ErrUniversalRequired, got %v", err)
 	}
+	// The doc contract on ErrUniversalRequired promises the underlying
+	// ErrNotFound is preserved in the wrap chain so callers can match
+	// either sentinel with errors.Is.
+	if !errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected ErrNotFound also reachable via errors.Is, got %v", err)
+	}
 }
 
 func TestComposeMissingSkillIsError(t *testing.T) {

--- a/internal/crew/skills/compose_test.go
+++ b/internal/crew/skills/compose_test.go
@@ -174,7 +174,11 @@ func TestComposePreservesPersonaTrimsTrailingNewlines(t *testing.T) {
 	}
 	// Persona's trailing newlines should be trimmed; persona+universal
 	// boundary should be exactly "\n\n".
+	//
+	// Failure message dumps the full output rather than slicing — a
+	// regression returning <60 chars must surface a clean test failure,
+	// not a slice panic that masks the real cause.
 	if !strings.HasPrefix(out, "PERSONA\n\n## Operator Universal Rules") {
-		t.Errorf("persona trim/separator wrong, got prefix:\n%s", out[:60])
+		t.Errorf("persona trim/separator wrong, got:\n%s", out)
 	}
 }

--- a/internal/crew/skills/compose_test.go
+++ b/internal/crew/skills/compose_test.go
@@ -48,7 +48,7 @@ func TestComposeOrderUniversalThenSkillThenProfile(t *testing.T) {
 	if uIdx < 0 || sIdx < 0 || pIdx < 0 {
 		t.Fatalf("Compose missing one of UNIV/SKILL/PROF in output:\n%s", out)
 	}
-	if !(uIdx < sIdx && sIdx < pIdx) {
+	if uIdx >= sIdx || sIdx >= pIdx {
 		t.Errorf("ordering wrong: UNIV=%d SKILL=%d PROF=%d", uIdx, sIdx, pIdx)
 	}
 }

--- a/internal/crew/skills/compose_test.go
+++ b/internal/crew/skills/compose_test.go
@@ -39,6 +39,20 @@ func TestComposeNilSourceReturnsError(t *testing.T) {
 	}
 }
 
+func TestComposeTypedNilSourceReturnsError(t *testing.T) {
+	// Go gotcha: a non-nil interface value holding a nil pointer
+	// (e.g. `var p *FilesystemSource = nil; var s Source = p`) passes
+	// `s == nil` (false) but panics on the first method call. Compose
+	// must catch this via the reflection-aware isNilSource helper.
+	var p *skills.FilesystemSource // nil pointer
+	var src skills.Source = p      // typed-nil stored in interface
+
+	_, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if !errors.Is(err, skills.ErrNilSource) {
+		t.Errorf("expected ErrNilSource for typed-nil source, got %v", err)
+	}
+}
+
 func TestComposeNoSkillsReturnsPersonaUnchanged(t *testing.T) {
 	src := MapSource{
 		"_universal.md": "should not appear when skills is empty",

--- a/internal/crew/skills/compose_test.go
+++ b/internal/crew/skills/compose_test.go
@@ -1,0 +1,151 @@
+package skills_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"klazomenai/bridge/internal/crew/skills"
+)
+
+func TestComposeEmptyPersonaReturnsError(t *testing.T) {
+	src := MapSource{}
+	_, err := skills.Compose("", []string{"github"}, src)
+	if !errors.Is(err, skills.ErrEmptyPersona) {
+		t.Errorf("expected ErrEmptyPersona, got %v", err)
+	}
+}
+
+func TestComposeNoSkillsReturnsPersonaUnchanged(t *testing.T) {
+	src := MapSource{
+		"_universal.md": "should not appear when skills is empty",
+	}
+	got, err := skills.Compose("PERSONA-X", nil, src)
+	if err != nil {
+		t.Fatalf("Compose: %v", err)
+	}
+	if got != "PERSONA-X" {
+		t.Errorf("Compose with no skills = %q, want %q", got, "PERSONA-X")
+	}
+	if strings.Contains(got, "should not appear") {
+		t.Error("universal content leaked into output despite empty skills")
+	}
+}
+
+func TestComposeOrderUniversalThenSkillThenProfile(t *testing.T) {
+	src := MapSource{
+		"_universal.md":     "UNIV-X",
+		"github/SKILL.md":   "SKILL-Y",
+		"github/profile.md": "PROF-Z",
+	}
+	out, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if err != nil {
+		t.Fatalf("Compose: %v", err)
+	}
+	uIdx := strings.Index(out, "UNIV-X")
+	sIdx := strings.Index(out, "SKILL-Y")
+	pIdx := strings.Index(out, "PROF-Z")
+	if uIdx < 0 || sIdx < 0 || pIdx < 0 {
+		t.Fatalf("Compose missing one of UNIV/SKILL/PROF in output:\n%s", out)
+	}
+	if !(uIdx < sIdx && sIdx < pIdx) {
+		t.Errorf("ordering wrong: UNIV=%d SKILL=%d PROF=%d", uIdx, sIdx, pIdx)
+	}
+}
+
+func TestComposeBoundaryMarkers(t *testing.T) {
+	src := MapSource{
+		"_universal.md":     "UNIV",
+		"github/SKILL.md":   "SKILL",
+		"github/profile.md": "PROF",
+	}
+	out, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if err != nil {
+		t.Fatalf("Compose: %v", err)
+	}
+	for _, marker := range []string{
+		"\n\n## Operator Universal Rules\n",
+		"\n\n## Github Workflow Rules\n",
+		"\n\n## Github Profile Addendum\n",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Errorf("missing boundary marker %q\nfull output:\n%s", marker, out)
+		}
+	}
+}
+
+func TestComposeMissingProfileFallsThrough(t *testing.T) {
+	src := MapSource{
+		"_universal.md":   "UNIV",
+		"github/SKILL.md": "SKILL",
+		// no profile
+	}
+	out, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if err != nil {
+		t.Fatalf("Compose: %v", err)
+	}
+	if !strings.Contains(out, "## Github Workflow Rules") {
+		t.Error("expected Workflow Rules section present")
+	}
+	if strings.Contains(out, "Profile Addendum") {
+		t.Error("expected NO Profile Addendum section when profile missing")
+	}
+}
+
+func TestComposeMissingUniversalIsError(t *testing.T) {
+	src := MapSource{
+		"github/SKILL.md": "SKILL",
+		// no universal
+	}
+	_, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if !errors.Is(err, skills.ErrUniversalRequired) {
+		t.Errorf("expected ErrUniversalRequired, got %v", err)
+	}
+}
+
+func TestComposeMissingSkillIsError(t *testing.T) {
+	src := MapSource{
+		"_universal.md": "UNIV",
+		// no github skill
+	}
+	_, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if !errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected ErrNotFound (wrapped), got %v", err)
+	}
+}
+
+func TestComposeMultipleSkillsInDeclarationOrder(t *testing.T) {
+	src := MapSource{
+		"_universal.md":       "UNIV",
+		"github/SKILL.md":     "GH-SKILL",
+		"kubernetes/SKILL.md": "K8S-SKILL",
+	}
+	out, err := skills.Compose("PERSONA", []string{"github", "kubernetes"}, src)
+	if err != nil {
+		t.Fatalf("Compose: %v", err)
+	}
+	ghIdx := strings.Index(out, "GH-SKILL")
+	k8sIdx := strings.Index(out, "K8S-SKILL")
+	if ghIdx < 0 || k8sIdx < 0 {
+		t.Fatalf("missing one of skill contents:\n%s", out)
+	}
+	if ghIdx >= k8sIdx {
+		t.Errorf("declaration order not preserved: gh=%d k8s=%d", ghIdx, k8sIdx)
+	}
+}
+
+func TestComposePreservesPersonaTrimsTrailingNewlines(t *testing.T) {
+	src := MapSource{
+		"_universal.md":   "UNIV",
+		"github/SKILL.md": "SKILL",
+	}
+	out, err := skills.Compose("PERSONA\n\n\n", []string{"github"}, src)
+	if err != nil {
+		t.Fatalf("Compose: %v", err)
+	}
+	// Persona's trailing newlines should be trimmed; persona+universal
+	// boundary should be exactly "\n\n".
+	if !strings.HasPrefix(out, "PERSONA\n\n## Operator Universal Rules") {
+		t.Errorf("persona trim/separator wrong, got prefix:\n%s", out[:60])
+	}
+}

--- a/internal/crew/skills/embedded.go
+++ b/internal/crew/skills/embedded.go
@@ -1,0 +1,15 @@
+package skills
+
+import "embed"
+
+// embeddedFS is the binary-baked mirror of the dotfiles content. The
+// directory layout exactly matches the FilesystemSource expected
+// structure so EmbeddedSource and FilesystemSource share the same
+// canonical path semantics.
+//
+// The content is re-synced from a pinned dotfiles ref via
+// `make sync-skills` (see Makefile). Drift is caught by CI in
+// .github/workflows/skills-drift.yml.
+//
+//go:embed embedded/*.md embedded/*/*.md
+var embeddedFS embed.FS

--- a/internal/crew/skills/embedded.go
+++ b/internal/crew/skills/embedded.go
@@ -2,17 +2,14 @@ package skills
 
 import "embed"
 
-// embeddedFS is the binary-baked mirror of the dotfiles content. The
-// directory layout exactly matches the FilesystemSource expected
+// embeddedFS is the binary-baked mirror of the dotfiles skill content.
+// The directory layout exactly matches the FilesystemSource expected
 // structure so EmbeddedSource and FilesystemSource share the same
 // canonical path semantics.
 //
-// The content is a frozen mirror of klazomenai/dotfiles main HEAD at
-// the time this package was authored; until the build/CI infrastructure
-// in #148e (Dockerfile multi-stage + Makefile sync-skills target +
-// drift CI) lands, bumps are manual: copy the three files from a local
-// dotfiles checkout into embedded/ and commit. See #148 for the
-// epic-level plan.
+// Bumps today are manual: copy the relevant files from a local
+// dotfiles checkout into embedded/ and commit alongside any code
+// changes that depend on the new content.
 //
 //go:embed embedded/*.md embedded/*/*.md
 var embeddedFS embed.FS

--- a/internal/crew/skills/embedded.go
+++ b/internal/crew/skills/embedded.go
@@ -7,9 +7,12 @@ import "embed"
 // structure so EmbeddedSource and FilesystemSource share the same
 // canonical path semantics.
 //
-// The content is re-synced from a pinned dotfiles ref via
-// `make sync-skills` (see Makefile). Drift is caught by CI in
-// .github/workflows/skills-drift.yml.
+// The content is a frozen mirror of klazomenai/dotfiles main HEAD at
+// the time this package was authored; until the build/CI infrastructure
+// in #148e (Dockerfile multi-stage + Makefile sync-skills target +
+// drift CI) lands, bumps are manual: copy the three files from a local
+// dotfiles checkout into embedded/ and commit. See #148 for the
+// epic-level plan.
 //
 //go:embed embedded/*.md embedded/*/*.md
 var embeddedFS embed.FS

--- a/internal/crew/skills/embedded/_universal.md
+++ b/internal/crew/skills/embedded/_universal.md
@@ -1,0 +1,130 @@
+# Agent Operating Rules — Universal
+
+This file is the cross-cutting agent profile that applies to every autonomous
+orchestrator persona, regardless of which skills they consume. It is loaded
+alongside any persona's individual skills.
+
+This file is **intentionally not referenced from any `SKILL.md`** — Claude
+Code never auto-loads it. The orchestrator (e.g. `klazomenai/bridge`)
+fetches this file by path at boot and concatenates it onto every persona's
+system prompt before any per-skill content.
+
+The behaviours encoded here are the safety baseline for autonomous-agent
+operation.
+
+## Repo / Resource Allowlist Enforcement
+
+Every write operation must verify the target resource (repository,
+namespace, pipeline, secret path, etc.) is in the orchestrator's allowlist
+before invoking the underlying tool.
+
+- Allowlist is fail-closed: empty list = refuse all writes.
+- Refusal must be visible to the operator with a clear explanation —
+  what was refused, why, and which configured allowlist applies.
+- Read-only operations may have a wider or empty allowlist depending on
+  the orchestrator's configuration — but writes are always gated.
+
+## Token & Secret Redaction
+
+- Tool output returned to the model must be sanitised for tokens, secrets,
+  and other sensitive values before the model sees it.
+- Use the orchestrator's shared redaction layer (e.g. a project-level
+  redaction package) — do not write per-tool ad-hoc filters.
+- Command lines logged for audit purposes must be token-redacted at log
+  time, not at display time.
+- Audit logs are persistent — redaction must happen before the log entry
+  is committed, not after retrieval.
+
+## Write Operations — Operator Intent Required
+
+Every write operation must reflect intent in the operator's most recent
+message. The user's request itself is the consent for that operation —
+e.g. "file an issue against bridge titled X" is sufficient consent to
+create the issue, no separate confirm step needed.
+
+Applies to ALL writes without exception: resource creation, comment
+posting, edit, label addition, status change, pipeline trigger, secret
+write, etc.
+
+Rules:
+
+- Don't infer write consent from earlier conversation. The relevant
+  message is the most recent operator turn.
+- Don't broaden scope ("close all open issues", "delete all stale pods")
+  without explicit confirmation on each target — a literal request is
+  per-target consent; set-quantified requests are not.
+- Ambiguity = ask, don't act.
+
+If the operator's most recent message does not literally describe the
+write you're considering, refuse and ask.
+
+**Pending-confirmation exception**: when a high-risk mutation is awaiting
+a separate confirmation, the literal-description requirement is satisfied
+by the *prior* operator message that proposed the action — the
+confirmation message itself does not need to repeat the description.
+Example sequence: operator says "Chips, close issue #99" → orchestrator
+asks "confirm close of issue #99?" → operator says "yes". The "yes" turn
+satisfies the literal-description rule via the prior turn that proposed
+the close.
+
+## High-Risk Mutations — Additional Confirmation Required
+
+Even when the operator's most recent message describes the action,
+certain mutations require a separate confirmation field/utterance because
+their consequences are unrecoverable, compound, or affect other people's
+expectations:
+
+- Closing or reopening an issue / PR
+- Pushing code (even to a feature branch the orchestrator has been
+  working on)
+- Resolving a review thread
+- Editing or deleting issue / PR / comment content already published
+- Destructive infrastructure operations — see the per-skill profile
+  addendum for skill-specific gates (e.g. `kubectl delete` of stateful
+  resources, `terraform destroy`, `vault token revoke`)
+- Operations that bypass a hook or permission rule
+
+For tools that support it, prefer a `confirm` boolean in the input schema
+that the persona must extract from the operator's words (not auto-fill).
+
+For specific tools listed as "refuse outright" in a per-skill profile
+(e.g. `gh pr merge`, `gh pr ready`), the persona must not register them
+as callable at all, regardless of operator confirmation.
+
+## Audit Trail
+
+Every write tool invocation should leave an audit record containing:
+
+- The command and (token-redacted) arguments
+- The target resource (repo, namespace, path)
+- The result (success / error, response status, response body summary)
+- The timestamp
+
+Audit records should be observable by the operator (Loki, structured
+stderr, file). Tool output returned to the model is not sufficient — it
+disappears from the conversation.
+
+## Refusal Policy
+
+When refusing a write, the persona must:
+
+- State what was refused
+- State why (allowlist, missing confirm, high-risk gate, etc.)
+- Surface the gate to the operator clearly enough that they can override
+  it explicitly if appropriate (rather than the operator having to guess
+  what the gate was)
+
+Don't refuse silently. Don't degrade the response by partially-completing.
+Don't substitute a "safer" action the operator didn't ask for.
+
+## Anti-Patterns
+
+- Acting on a write request without checking the resource allowlist first
+- Returning unredacted tool output to the model
+- Inferring mutation consent from earlier conversation rather than the
+  most recent operator message (or its pending-confirmation predecessor)
+- Logging full command lines (including token values) for audit
+- Refusing silently — every refusal must surface the gate
+- Substituting a "safer" action the operator didn't ask for
+- Treating a tool as callable that the per-skill profile lists as
+  "refuse outright" (the tool must not be registered at all)

--- a/internal/crew/skills/embedded/github/SKILL.md
+++ b/internal/crew/skills/embedded/github/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: github
+description: Git and GitHub workflow guidance, including commits, branches, PRs, issues, reviews, and labels. Use when working with git commands, GitHub issues, pull requests, or code reviews.
+---
+
+# Git + GitHub Skill
+
+This skill encodes the universal git + GitHub workflow rules — they apply
+wherever this skill is loaded, including by autonomous agents that vendor
+or link this file. Operator-specific concerns (Claude co-author handling on
+private repos, hook UX) live in `claude/CLAUDE.md`. Agent-specific
+constraints (allowlist enforcement, mutation gating, no-autonomous-merge)
+live in `claude/profiles/` for orchestrator consumers — Claude Code never
+loads that directory.
+
+## Commit Conventions
+
+- Conventional commits format: `<type>(scope): description`
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `perf`, `security`
+- Signed commits required: always use `--gpg-sign`
+- Use `Refs #N` in commit body — NEVER `Closes #N`, `Fixes #N`, or `Resolves #N` (closing is a merge-time decision)
+- NEVER amend commits or force-push — stack separate signed commits, squash on merge
+- Commit emoji prefixes (in commit message, not branch): ✨ feat | 🐛 fix | 📝 docs | ♻️ refactor | 🧪 test | ⚙️ chore | 🔐 security | 🏗️ ci | ⚡ perf
+
+## Branch Conventions
+
+- NEVER push to "main" or default branch — NO EXCEPTIONS
+- NEVER create "master" branch
+- Naming: `<type>/<issue>-<description>` e.g. `feat/595-jaeger-tracing`, `fix/784-terraform-exit-code`
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `security`, `spike`
+- Base branch: main | Merge style: squash merge | Delete branch after merge
+- No emojis in branch names
+
+## PR Workflow
+
+- ALWAYS create PRs as draft: `gh pr create --draft`
+- After creating a PR, STOP. Provide the PR URL. Do NOT suggest merging or next steps.
+- NEVER run `gh pr merge` or `gh pr ready` — merging is a human decision after peer review
+- CI passing does NOT mean ready to merge
+- Conventional commit format for PR titles: `<type>(scope): description`
+- PR title emojis go at the END of the title
+- PR body format:
+  ```
+  ## Summary
+  <1-3 bullet points>
+
+  ## Test plan
+  - [ ] Bulleted checklist of testing TODOs
+  ```
+- Write PR bodies to temp files for safe escaping of complex content: `gh pr create --body-file path/to/file --draft ...`. (Note: `--body-file <path>` is the `gh pr create` flag; the `-F body=@file` form-field syntax is for `gh api` calls only — see PR Review Replies below.)
+
+## Issue Conventions
+
+- Conventional prefix on issue titles: `feat:`, `fix:`, `chore:`, etc.
+- Emojis go at the END of issue titles
+- Type emojis: 🐙 Epic | 🔍 Spike | 📊 Dashboard | 🔔 Alert | 🚪 Gateway | 🔐 Security | 🪦 Decommission
+- Status emojis: ✅ Done | ❌ Blocked | ⏸️ Paused | 🚧 WIP | 📋 Planned
+
+## Labels
+
+- Standard: `epic`, `spike`, `bug`, `enhancement`, `refactor`, `techdebt`
+- Namespaced: `app:*`, `env:*`, `fun:*`, `ws:*`, `depth:*`, `priority:*`, `provider:*`
+
+## Copilot Review Workflow
+
+When handling Copilot PR review comments, follow this process:
+
+1. **Read** — `gh api repos/{owner}/{repo}/pulls/{pr}/comments`, filter top-level only (where `in_reply_to_id` is null)
+2. **Discuss** — present each comment with assessment (agree/disagree/partial), explain reasoning with technical justification
+3. **User decides** — wait for explicit confirmation on which comments to address
+4. **Fix locally** — make the code changes
+5. **Test locally before pushing** — run changed code from working tree (e.g. `bash -n`, `bash -x` with timeout). Reduce pipeline waste.
+6. **Commit and push** — new commit on same branch (never amend)
+7. **Reply inline** — write body to temp file, then `gh api repos/{owner}/{repo}/pulls/{pr}/comments -X POST -F "body=@$tmpfile" -F in_reply_to=<id>`, reference commit SHA
+
+Rules:
+- Push back on wrong suggestions with technical reasoning — not every comment is correct
+- Reply to EVERY top-level comment, even when disagreeing
+- Reference the fix commit SHA in replies where changes were made
+
+> **Why stack, not amend**: squash merge collapses all commits at merge time. Amending rewrites history reviewers already inspected, and force-push triggers guardrail hooks — for zero benefit.
+
+## PR Review Replies
+
+When replying to PR review comments:
+
+- Write reply body to a temp file for safe escaping of complex content
+- Pattern: `tmpfile=$(mktemp) && cat <<'EOF' > "$tmpfile" ... EOF` then `gh api ... -F "body=@$tmpfile" -F in_reply_to=<id> && rm -f "$tmpfile"`
+- Always reply inline to the specific comment thread, not as a standalone comment
+
+## Public Repo Security
+
+CRITICAL — applies to ALL public-facing text in public repositories,
+regardless of who or what is generating that text:
+
+- NEVER reference private org names, private repo names, or internal
+  infrastructure
+- Sanitisation applies to EVERYTHING: PR titles, PR bodies, commit messages,
+  branch names, issue titles, issue bodies, review-comment replies — not
+  just file contents
+- Before creating or editing a public-repo artefact: review the artefact in
+  full — every surface listed above (PR title, PR body, commit message,
+  branch name, issue title, issue body, review-comment reply) for any
+  private/internal references, regardless of where the source text came
+  from (operator instruction, tool output, prior conversation context)
+- `gh repo create --push` pushes straight to main — NEVER use `--push` flag
+
+The risk is the same whether the source is a human's local environment
+(private hostnames, customer references, internal service names) or an
+autonomous agent's tool output (e.g. a `kubectl` result mentioning a
+private internal service that gets transcribed into an issue body).
+Generated text bound for public surfaces gets the same scrutiny as
+hand-typed text.
+
+## Sensitive Values in Command Arguments
+
+CRITICAL — applies to all command invocations, whether by a human at a
+shell or by an autonomous agent invoking subprocesses:
+
+- NEVER inline sensitive values (emails, keys, passwords, tokens) in
+  command arguments — they leak into shell history, process tables, audit
+  logs, and conversation logs
+- Set env vars out-of-band (login env, restricted-perm `.env` file, secrets
+  manager); pass via file paths (`gh auth login --with-token < tokenfile`,
+  `kubectl create secret generic --from-file=key=/dev/stdin`); or pipe via
+  stdin where the tool supports it (`docker login --password-stdin`,
+  `helm registry login --password-stdin`)
+- Don't recommend any pattern where the secret value appears in a logged
+  command line — `export VAR=value` typed at a shell still ends up in
+  history; prefer mechanisms that never put the value in argv at all
+- Applies to all CLIs: `gh`, `terraform`, `gcloud`, `kubectl`, `vault`,
+  `aut`, etc.
+- Audit logs are persistent — agents that log full command lines for
+  audit purposes are a particular leak risk; redact at log-time, not
+  display-time
+
+## File Hygiene
+
+- Newlines at EOF
+- No trailing whitespace
+- LF line endings (no CRLF)
+- Never commit secrets (.env, credentials, keys, tokens)
+- Never commit `.terraform/`, `.tfstate`, `node_modules/`, or other generated artifacts
+
+## Anti-Patterns to Flag
+
+- Pushing directly to main or default branch
+- Creating "master" branches
+- Using `Closes #N`, `Fixes #N`, or `Resolves #N` in commit messages (use `Refs #N`)
+- Using `gh pr merge` or `gh pr ready` (merging is a human decision)
+- Creating non-draft PRs
+- Committing secrets or credentials
+- Using `gh repo create --push` (pushes to main)
+- Amending commits during PR review (`--amend`) — stack new signed commits; squash merge makes amend pointless
+- Force-pushing (`--force`, `--force-with-lease`) — breaks reviewer context, blocked by guardrail hooks
+- Emojis in branch names or code

--- a/internal/crew/skills/embedded/github/profile.md
+++ b/internal/crew/skills/embedded/github/profile.md
@@ -1,0 +1,75 @@
+# Agent Operating Rules — Git + GitHub Workflow
+
+This file is the GitHub-specific agent profile addendum. It is loaded
+alongside `_universal.md` for any persona that consumes the `github`
+skill.
+
+This file is **intentionally not referenced from
+`claude/skills/github/SKILL.md`** — Claude Code never auto-loads it.
+Orchestrators (e.g. `klazomenai/bridge`) fetch this file by path at boot.
+
+The universal workflow rules in `claude/skills/github/SKILL.md` apply to
+both human Claude Code users and autonomous agents. The cross-cutting
+agent rules in `claude/profiles/_universal.md` apply to every persona
+regardless of skill. The rules below are the GitHub-specific additions
+for autonomous agents.
+
+## PR Lifecycle Gates
+
+The universal SKILL.md says: NEVER run `gh pr merge` or `gh pr ready` —
+merging is a human decision after peer review. For autonomous agents
+this is hardened from a rule to a tool-registration constraint:
+
+- `gh pr merge` and `gh pr ready` must not be exposed as callable tools
+  to the persona. The persona cannot invoke them even with explicit
+  operator confirmation. Removing the tool from the registry is the
+  correct enforcement, not a runtime refusal.
+- `gh pr create` must be exposed only with `--draft` baked in. The
+  tool's input schema must reject `draft=false`.
+
+## Pushing Code
+
+The universal SKILL.md says: don't amend, don't force-push, stack on the
+same branch. For autonomous agents:
+
+- Pushing code (even to a feature branch the orchestrator has been
+  working on) requires explicit operator confirmation per the high-risk
+  mutation gating rule in `_universal.md`. The agent does not infer
+  push consent from "we just made a fix".
+- The agent never invokes `git push --force` or
+  `git push --force-with-lease` regardless of operator confirmation —
+  these are refused outright.
+
+## Copilot Review Threads
+
+The universal SKILL.md describes the read → discuss → user-decides →
+fix → test → push → reply workflow. For autonomous agents:
+
+- NEVER autonomously resolve Copilot review threads. Reply per the
+  universal workflow (citing a fix-commit SHA when changes were made;
+  disagree-only replies are valid without a SHA); the operator resolves
+  the thread.
+- "Apply all suggestions" is not a valid action without explicit
+  operator consent on each comment.
+- Always present each top-level Copilot comment to the operator with
+  the agent's assessment (agree / disagree / partial); do not silently
+  filter comments out.
+
+## Branch Operations
+
+- The agent never creates a `master` branch. Refused outright.
+- The agent never pushes to `main` or the default branch. Refused
+  outright, regardless of operator confirmation.
+- The agent never amends commits during PR review or rebases a
+  published branch. Refused outright.
+
+## Anti-Patterns
+
+- Resolving Copilot review threads autonomously
+- Calling `gh pr merge` or `gh pr ready` (these tools must not be
+  registered)
+- Calling `gh pr create` without `--draft`
+- Creating non-draft PRs through any path
+- Pushing code without explicit operator confirmation
+- Force-pushing or rebasing published branches
+- Amending commits during PR review

--- a/internal/crew/skills/loader.go
+++ b/internal/crew/skills/loader.go
@@ -19,13 +19,39 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
+	"regexp"
 )
 
 // ErrNotFound is the sentinel returned by Source implementations when
 // a requested document does not exist. Wrapped errors that include it
 // are matched via errors.Is.
 var ErrNotFound = errors.New("skills: doc not found")
+
+// ErrInvalidSkillName is returned by Source implementations when the
+// supplied skill name violates the naming convention. The constraint
+// is intentionally strict: only lowercase letters, digits, and dashes;
+// must start with a letter or digit. This rejects path-traversal
+// attempts (`..`, `/`, `\`) and shell-meaningful characters at the
+// type-system boundary, irrespective of whether the operator-controlled
+// `crew.yaml` is the only producer of skill names today.
+var ErrInvalidSkillName = errors.New("skills: invalid skill name")
+
+// skillNamePattern matches the dotfiles `claude/skills/<name>/` naming
+// convention: lowercase alphanumeric with optional dashes.
+var skillNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// validateSkillName rejects names that would escape <Root>/ or break
+// the canonical relative path structure used by Doc.Path. Applied at
+// every Source.Skill / Source.Profile entry point so any future Source
+// implementation inherits the guarantee.
+func validateSkillName(name string) error {
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("%w: %q", ErrInvalidSkillName, name)
+	}
+	return nil
+}
 
 // Doc is a single loaded skill artefact. Path is the source-relative
 // canonical key (e.g. "_universal.md", "github/SKILL.md",
@@ -67,18 +93,30 @@ func (s FilesystemSource) Universal() (Doc, error) {
 	return s.read("_universal.md")
 }
 
-// Skill returns <Root>/<name>/SKILL.md.
+// Skill returns <Root>/<name>/SKILL.md. Returns ErrInvalidSkillName
+// (wrapped) if name fails validation.
 func (s FilesystemSource) Skill(name string) (Doc, error) {
-	return s.read(filepath.Join(name, "SKILL.md"))
+	if err := validateSkillName(name); err != nil {
+		return Doc{}, err
+	}
+	return s.read(path.Join(name, "SKILL.md"))
 }
 
-// Profile returns <Root>/<name>/profile.md.
+// Profile returns <Root>/<name>/profile.md. Returns ErrInvalidSkillName
+// (wrapped) if name fails validation.
 func (s FilesystemSource) Profile(name string) (Doc, error) {
-	return s.read(filepath.Join(name, "profile.md"))
+	if err := validateSkillName(name); err != nil {
+		return Doc{}, err
+	}
+	return s.read(path.Join(name, "profile.md"))
 }
 
+// read takes a slash-separated canonical path (the same shape used in
+// Doc.Path) and resolves it on disk via filepath.FromSlash so the
+// canonical key stays OS-independent while the on-disk read uses the
+// host's path separator.
 func (s FilesystemSource) read(rel string) (Doc, error) {
-	full := filepath.Join(s.Root, rel)
+	full := filepath.Join(s.Root, filepath.FromSlash(rel))
 	content, err := os.ReadFile(full)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -101,15 +139,27 @@ func (EmbeddedSource) Universal() (Doc, error) {
 	return readFromFS(embeddedFS, "embedded/_universal.md", "_universal.md")
 }
 
-// Skill reads embedded/<name>/SKILL.md.
+// Skill reads embedded/<name>/SKILL.md. Returns ErrInvalidSkillName
+// (wrapped) if name fails validation.
+//
+// embed.FS uses slash-separated paths regardless of OS, so path.Join
+// (not filepath.Join) is used both for the embedded lookup and the
+// canonical Doc.Path so the return value is OS-independent.
 func (EmbeddedSource) Skill(name string) (Doc, error) {
-	rel := filepath.Join(name, "SKILL.md")
+	if err := validateSkillName(name); err != nil {
+		return Doc{}, err
+	}
+	rel := path.Join(name, "SKILL.md")
 	return readFromFS(embeddedFS, "embedded/"+rel, rel)
 }
 
-// Profile reads embedded/<name>/profile.md.
+// Profile reads embedded/<name>/profile.md. Returns ErrInvalidSkillName
+// (wrapped) if name fails validation.
 func (EmbeddedSource) Profile(name string) (Doc, error) {
-	rel := filepath.Join(name, "profile.md")
+	if err := validateSkillName(name); err != nil {
+		return Doc{}, err
+	}
+	rel := path.Join(name, "profile.md")
 	return readFromFS(embeddedFS, "embedded/"+rel, rel)
 }
 

--- a/internal/crew/skills/loader.go
+++ b/internal/crew/skills/loader.go
@@ -29,6 +29,13 @@ import (
 // are matched via errors.Is.
 var ErrNotFound = errors.New("skills: doc not found")
 
+// ErrNilSource is the sentinel returned when a Source argument is nil.
+// Returned by Compose (when the src parameter is nil) and by
+// FallbackSource methods (when Primary or Secondary is nil) so caller
+// misconfiguration is reported via the error path instead of a
+// runtime panic.
+var ErrNilSource = errors.New("skills: nil source")
+
 // ErrInvalidSkillName is returned by Source implementations when the
 // supplied skill name violates the naming convention. The constraint
 // is intentionally strict: only lowercase letters, digits, and dashes;
@@ -190,13 +197,29 @@ type FallbackSource struct {
 	Primary, Secondary Source
 }
 
+// validate returns ErrNilSource if either Primary or Secondary is nil.
+// Called at the top of every FallbackSource method so misconfiguration
+// surfaces as an error rather than a panic at the closure dereference.
+func (f FallbackSource) validate() error {
+	if f.Primary == nil || f.Secondary == nil {
+		return fmt.Errorf("%w: FallbackSource requires both Primary and Secondary", ErrNilSource)
+	}
+	return nil
+}
+
 // Universal tries Primary, falling back to Secondary on ErrNotFound.
 func (f FallbackSource) Universal() (Doc, error) {
+	if err := f.validate(); err != nil {
+		return Doc{}, err
+	}
 	return f.tryFallback(f.Primary.Universal, f.Secondary.Universal)
 }
 
 // Skill tries Primary, falling back to Secondary on ErrNotFound.
 func (f FallbackSource) Skill(name string) (Doc, error) {
+	if err := f.validate(); err != nil {
+		return Doc{}, err
+	}
 	return f.tryFallback(
 		func() (Doc, error) { return f.Primary.Skill(name) },
 		func() (Doc, error) { return f.Secondary.Skill(name) },
@@ -205,6 +228,9 @@ func (f FallbackSource) Skill(name string) (Doc, error) {
 
 // Profile tries Primary, falling back to Secondary on ErrNotFound.
 func (f FallbackSource) Profile(name string) (Doc, error) {
+	if err := f.validate(); err != nil {
+		return Doc{}, err
+	}
 	return f.tryFallback(
 		func() (Doc, error) { return f.Primary.Profile(name) },
 		func() (Doc, error) { return f.Secondary.Profile(name) },

--- a/internal/crew/skills/loader.go
+++ b/internal/crew/skills/loader.go
@@ -79,11 +79,14 @@ type Source interface {
 	Profile(name string) (Doc, error)
 }
 
-// FilesystemSource reads from a configurable root path.
+// FilesystemSource reads from a caller-provided root path. Doc.Path
+// values are slash-separated regardless of host OS so the API contract
+// stays consistent with EmbeddedSource.
 //
-// Production: /var/lib/klazomenai/skills (set in the Bridge image
-// by the Dockerfile dotfiles stage).
-// Development: KLAZOMENAI_SKILLS_DIR env var override.
+// The production wiring (image-baked /var/lib/klazomenai/skills mount,
+// KLAZOMENAI_SKILLS_DIR env override, Dockerfile multi-stage build of
+// the dotfiles bundle) lands in #148e. Today this struct only supplies
+// the read surface; callers choose Root.
 type FilesystemSource struct {
 	Root string
 }
@@ -175,11 +178,14 @@ func readFromFS(fsys fs.FS, embeddedPath, canonicalPath string) (Doc, error) {
 }
 
 // FallbackSource composes Primary then Secondary. ErrNotFound from
-// Primary falls through to Secondary; all other errors short-circuit.
+// Primary falls through to Secondary; all other errors short-circuit
+// (so a permission-denied on Primary is not silently masked by
+// Secondary's content).
 //
-// Used in production to layer FilesystemSource (allowing operator
-// override via the image's /var/lib/klazomenai/skills mount) over
-// EmbeddedSource (the binary-baked fallback).
+// The intended production layering — FilesystemSource as primary so
+// operators can override image-baked content, EmbeddedSource as
+// secondary so a missing/unmounted directory falls back gracefully —
+// is wired up in #148c. This sub-PR ships only the composition shape.
 type FallbackSource struct {
 	Primary, Secondary Source
 }

--- a/internal/crew/skills/loader.go
+++ b/internal/crew/skills/loader.go
@@ -1,0 +1,167 @@
+// Package skills provides the loader/compose surface for Bridge's
+// skill-based system-prompt augmentation. It is consumed by
+// klazomenai/bridge/internal/crew at registry-load time.
+//
+// The package implements three Source variants (FilesystemSource,
+// EmbeddedSource, FallbackSource) over the documented dotfiles layout:
+//
+//	_universal.md
+//	<skill>/SKILL.md
+//	<skill>/profile.md
+//
+// Compose renders a persona system prompt augmented with the universal
+// addendum, per-skill SKILL.md content, and per-skill profile content
+// (where present). See compose.go for output format.
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ErrNotFound is the sentinel returned by Source implementations when
+// a requested document does not exist. Wrapped errors that include it
+// are matched via errors.Is.
+var ErrNotFound = errors.New("skills: doc not found")
+
+// Doc is a single loaded skill artefact. Path is the source-relative
+// canonical key (e.g. "_universal.md", "github/SKILL.md",
+// "github/profile.md") used for diagnostics and golden-file comparison.
+type Doc struct {
+	Path    string
+	Content string
+}
+
+// Source resolves skill documents by their canonical relative path.
+// Implementations mirror the dotfiles layout exactly.
+type Source interface {
+	// Universal returns the operator-universal addendum (_universal.md).
+	// Returns ErrNotFound (wrapped) if absent — Compose treats this as
+	// fatal when the calling crew has declared at least one skill.
+	Universal() (Doc, error)
+	// Skill returns the SKILL.md for a named skill (e.g. "github").
+	// Returns ErrNotFound (wrapped) if the source doesn't contain the
+	// named skill — Compose treats this as fatal.
+	Skill(name string) (Doc, error)
+	// Profile returns the per-skill profile addendum (e.g.
+	// "github/profile.md"). Returns ErrNotFound (wrapped) if no profile
+	// exists for that skill — Compose treats this as soft (skill renders
+	// without a profile section).
+	Profile(name string) (Doc, error)
+}
+
+// FilesystemSource reads from a configurable root path.
+//
+// Production: /var/lib/klazomenai/skills (set in the Bridge image
+// by the Dockerfile dotfiles stage).
+// Development: KLAZOMENAI_SKILLS_DIR env var override.
+type FilesystemSource struct {
+	Root string
+}
+
+// Universal returns the universal addendum at <Root>/_universal.md.
+func (s FilesystemSource) Universal() (Doc, error) {
+	return s.read("_universal.md")
+}
+
+// Skill returns <Root>/<name>/SKILL.md.
+func (s FilesystemSource) Skill(name string) (Doc, error) {
+	return s.read(filepath.Join(name, "SKILL.md"))
+}
+
+// Profile returns <Root>/<name>/profile.md.
+func (s FilesystemSource) Profile(name string) (Doc, error) {
+	return s.read(filepath.Join(name, "profile.md"))
+}
+
+func (s FilesystemSource) read(rel string) (Doc, error) {
+	full := filepath.Join(s.Root, rel)
+	content, err := os.ReadFile(full)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Doc{}, fmt.Errorf("filesystem source %s: %w", full, ErrNotFound)
+		}
+		return Doc{}, fmt.Errorf("filesystem source %s: %w", full, err)
+	}
+	return Doc{Path: rel, Content: string(content)}, nil
+}
+
+// EmbeddedSource reads from the //go:embed FS rooted at the package's
+// embedded/ subdirectory. Used as the test fallback and as the
+// production fallback when FilesystemSource fails (e.g. the image
+// mount is missing or the dotfiles ref pinned at build time has not
+// been bundled correctly).
+type EmbeddedSource struct{}
+
+// Universal reads embedded/_universal.md.
+func (EmbeddedSource) Universal() (Doc, error) {
+	return readFromFS(embeddedFS, "embedded/_universal.md", "_universal.md")
+}
+
+// Skill reads embedded/<name>/SKILL.md.
+func (EmbeddedSource) Skill(name string) (Doc, error) {
+	rel := filepath.Join(name, "SKILL.md")
+	return readFromFS(embeddedFS, "embedded/"+rel, rel)
+}
+
+// Profile reads embedded/<name>/profile.md.
+func (EmbeddedSource) Profile(name string) (Doc, error) {
+	rel := filepath.Join(name, "profile.md")
+	return readFromFS(embeddedFS, "embedded/"+rel, rel)
+}
+
+func readFromFS(fsys fs.FS, embeddedPath, canonicalPath string) (Doc, error) {
+	content, err := fs.ReadFile(fsys, embeddedPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Doc{}, fmt.Errorf("embedded source %s: %w", embeddedPath, ErrNotFound)
+		}
+		return Doc{}, fmt.Errorf("embedded source %s: %w", embeddedPath, err)
+	}
+	return Doc{Path: canonicalPath, Content: string(content)}, nil
+}
+
+// FallbackSource composes Primary then Secondary. ErrNotFound from
+// Primary falls through to Secondary; all other errors short-circuit.
+//
+// Used in production to layer FilesystemSource (allowing operator
+// override via the image's /var/lib/klazomenai/skills mount) over
+// EmbeddedSource (the binary-baked fallback).
+type FallbackSource struct {
+	Primary, Secondary Source
+}
+
+// Universal tries Primary, falling back to Secondary on ErrNotFound.
+func (f FallbackSource) Universal() (Doc, error) {
+	return f.tryFallback(f.Primary.Universal, f.Secondary.Universal)
+}
+
+// Skill tries Primary, falling back to Secondary on ErrNotFound.
+func (f FallbackSource) Skill(name string) (Doc, error) {
+	return f.tryFallback(
+		func() (Doc, error) { return f.Primary.Skill(name) },
+		func() (Doc, error) { return f.Secondary.Skill(name) },
+	)
+}
+
+// Profile tries Primary, falling back to Secondary on ErrNotFound.
+func (f FallbackSource) Profile(name string) (Doc, error) {
+	return f.tryFallback(
+		func() (Doc, error) { return f.Primary.Profile(name) },
+		func() (Doc, error) { return f.Secondary.Profile(name) },
+	)
+}
+
+func (FallbackSource) tryFallback(primary, secondary func() (Doc, error)) (Doc, error) {
+	doc, err := primary()
+	if err == nil {
+		return doc, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return Doc{}, err
+	}
+	return secondary()
+}

--- a/internal/crew/skills/loader.go
+++ b/internal/crew/skills/loader.go
@@ -1,6 +1,5 @@
-// Package skills provides the loader/compose surface for Bridge's
-// skill-based system-prompt augmentation. It is consumed by
-// klazomenai/bridge/internal/crew at registry-load time.
+// Package skills provides a loader/compose surface for skill-based
+// system-prompt augmentation.
 //
 // The package implements three Source variants (FilesystemSource,
 // EmbeddedSource, FallbackSource) over the documented dotfiles layout:
@@ -12,6 +11,9 @@
 // Compose renders a persona system prompt augmented with the universal
 // addendum, per-skill SKILL.md content, and per-skill profile content
 // (where present). See compose.go for output format.
+//
+// This package is purely additive: callers will be wired up in a
+// later sub-PR.
 package skills
 
 import (
@@ -21,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 )
 
@@ -35,6 +38,24 @@ var ErrNotFound = errors.New("skills: doc not found")
 // misconfiguration is reported via the error path instead of a
 // runtime panic.
 var ErrNilSource = errors.New("skills: nil source")
+
+// isNilSource detects both the bare-nil interface case (s == nil) and
+// the typed-nil case (s holds a non-nil type pointer with nil value,
+// e.g. var p *FilesystemSource = nil; var s Source = p). The latter
+// would otherwise pass an `s == nil` check yet panic at the first
+// method call — a subtle Go gotcha worth defending against at every
+// public-API entry point that takes a Source.
+func isNilSource(s Source) bool {
+	if s == nil {
+		return true
+	}
+	rv := reflect.ValueOf(s)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice:
+		return rv.IsNil()
+	}
+	return false
+}
 
 // ErrInvalidSkillName is returned by Source implementations when the
 // supplied skill name violates the naming convention. The constraint
@@ -89,11 +110,6 @@ type Source interface {
 // FilesystemSource reads from a caller-provided root path. Doc.Path
 // values are slash-separated regardless of host OS so the API contract
 // stays consistent with EmbeddedSource.
-//
-// The production wiring (image-baked /var/lib/klazomenai/skills mount,
-// KLAZOMENAI_SKILLS_DIR env override, Dockerfile multi-stage build of
-// the dotfiles bundle) lands in #148e. Today this struct only supplies
-// the read surface; callers choose Root.
 type FilesystemSource struct {
 	Root string
 }
@@ -187,21 +203,17 @@ func readFromFS(fsys fs.FS, embeddedPath, canonicalPath string) (Doc, error) {
 // FallbackSource composes Primary then Secondary. ErrNotFound from
 // Primary falls through to Secondary; all other errors short-circuit
 // (so a permission-denied on Primary is not silently masked by
-// Secondary's content).
-//
-// The intended production layering — FilesystemSource as primary so
-// operators can override image-baked content, EmbeddedSource as
-// secondary so a missing/unmounted directory falls back gracefully —
-// is wired up in #148c. This sub-PR ships only the composition shape.
+// Secondary's content). Both fields must be non-nil — see validate.
 type FallbackSource struct {
 	Primary, Secondary Source
 }
 
-// validate returns ErrNilSource if either Primary or Secondary is nil.
-// Called at the top of every FallbackSource method so misconfiguration
-// surfaces as an error rather than a panic at the closure dereference.
+// validate returns ErrNilSource if either Primary or Secondary is nil
+// (or typed-nil — see isNilSource). Called at the top of every
+// FallbackSource method so misconfiguration surfaces as an error
+// rather than a panic at the closure dereference.
 func (f FallbackSource) validate() error {
-	if f.Primary == nil || f.Secondary == nil {
+	if isNilSource(f.Primary) || isNilSource(f.Secondary) {
 		return fmt.Errorf("%w: FallbackSource requires both Primary and Secondary", ErrNilSource)
 	}
 	return nil

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -143,13 +143,39 @@ func TestEmbeddedSourceUnknownSkillReturnsErrNotFound(t *testing.T) {
 	}
 }
 
-func TestEmbeddedSourceSkillWithoutProfileReturnsErrNotFound(t *testing.T) {
-	// github currently has both SKILL.md AND profile.md, so this test
-	// pins the contract: when a skill has no profile, Profile() returns
-	// ErrNotFound. Once a skill ships without a profile addendum, this
-	// test exercises that path.
+func TestEmbeddedSourceProfileForUnknownSkillReturnsErrNotFound(t *testing.T) {
+	// Profile() for an unknown skill name (one that has neither SKILL.md
+	// nor profile.md in the embedded fixtures) must return ErrNotFound,
+	// not a different sentinel — Compose treats this as soft and skips
+	// the profile section. The complementary "skill exists but profile
+	// missing" semantic is exercised separately in
+	// TestFilesystemSourceProfileMissingForExistingSkillReturnsErrNotFound,
+	// where a temp-dir fixture lets us pin that contract directly.
 	src := skills.EmbeddedSource{}
 	_, err := src.Profile("nonexistent-skill")
+	if !errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFilesystemSourceProfileMissingForExistingSkillReturnsErrNotFound(t *testing.T) {
+	// Genuine "skill present, profile absent" coverage: seed only
+	// <tmp>/foo/SKILL.md (no profile.md), then assert Profile("foo")
+	// returns ErrNotFound. Compose's missing-profile-falls-through
+	// branch relies on this exact sentinel.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "foo"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "foo", "SKILL.md"), []byte("SKILL"), 0o600); err != nil {
+		t.Fatalf("seed SKILL.md: %v", err)
+	}
+	// Sanity: skill itself is present.
+	if _, err := (skills.FilesystemSource{Root: dir}).Skill("foo"); err != nil {
+		t.Fatalf("Skill(foo) seeding broken: %v", err)
+	}
+	// The contract under test: profile is absent → ErrNotFound.
+	_, err := (skills.FilesystemSource{Root: dir}).Profile("foo")
 	if !errors.Is(err, skills.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -226,8 +226,12 @@ func TestSourceAcceptsValidSkillName(t *testing.T) {
 // ----------------------------------------------------------------------
 
 func TestFallbackSourceUsesEmbeddedWhenFilesystemMissing(t *testing.T) {
+	// Construct a guaranteed-missing path under t.TempDir() rather than
+	// hardcoding "/nonexistent/path" (POSIX-only and host-dependent).
+	// The TempDir itself exists; the subdir we name does not.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
 	src := skills.FallbackSource{
-		Primary:   skills.FilesystemSource{Root: "/nonexistent/path"},
+		Primary:   skills.FilesystemSource{Root: missing},
 		Secondary: skills.EmbeddedSource{},
 	}
 	doc, err := src.Skill("github")
@@ -258,6 +262,33 @@ func TestFallbackSourceUsesFilesystemWhenPresent(t *testing.T) {
 	}
 	if doc.Content != "OVERRIDE-SENTINEL" {
 		t.Errorf("filesystem primary should win, got %q", doc.Content)
+	}
+}
+
+func TestFallbackSourceRejectsNilPrimaryOrSecondary(t *testing.T) {
+	// Misconfiguration (forgetting Primary or Secondary at construction
+	// time) should surface as ErrNilSource, not panic at the closure
+	// dereference inside tryFallback.
+	cases := []struct {
+		name string
+		src  skills.FallbackSource
+	}{
+		{"nil primary", skills.FallbackSource{Primary: nil, Secondary: skills.EmbeddedSource{}}},
+		{"nil secondary", skills.FallbackSource{Primary: skills.EmbeddedSource{}, Secondary: nil}},
+		{"both nil", skills.FallbackSource{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.src.Universal(); !errors.Is(err, skills.ErrNilSource) {
+				t.Errorf("Universal: expected ErrNilSource, got %v", err)
+			}
+			if _, err := tc.src.Skill("github"); !errors.Is(err, skills.ErrNilSource) {
+				t.Errorf("Skill: expected ErrNilSource, got %v", err)
+			}
+			if _, err := tc.src.Profile("github"); !errors.Is(err, skills.ErrNilSource) {
+				t.Errorf("Profile: expected ErrNilSource, got %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -236,9 +236,12 @@ func TestSourceAcceptsValidSkillName(t *testing.T) {
 	}
 	for _, name := range cases {
 		t.Run(name, func(t *testing.T) {
-			// The skill won't exist in the embedded source, so the
-			// expected error is ErrNotFound, NOT ErrInvalidSkillName —
-			// proving validation accepts the name and lookup proceeds.
+			// Pins one thing only: validation accepts the name. The
+			// downstream lookup outcome varies per case (nil for
+			// "github" which exists in embedded fixtures; ErrNotFound
+			// for the others) and is irrelevant here — what matters
+			// is that the error is NOT ErrInvalidSkillName, proving
+			// validation didn't over-reject.
 			_, err := skills.EmbeddedSource{}.Skill(name)
 			if errors.Is(err, skills.ErrInvalidSkillName) {
 				t.Errorf("Skill(%q): unexpectedly rejected as invalid", name)

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -1,0 +1,217 @@
+package skills_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"klazomenai/bridge/internal/crew/skills"
+)
+
+// MapSource is a test-only Source backed by an in-memory map keyed by
+// canonical relative path (e.g. "_universal.md", "github/SKILL.md").
+// Used by Compose tests to inject precise document content without
+// filesystem or embed.FS dependencies.
+type MapSource map[string]string
+
+func (m MapSource) Universal() (skills.Doc, error) {
+	return m.lookup("_universal.md")
+}
+
+func (m MapSource) Skill(name string) (skills.Doc, error) {
+	return m.lookup(filepath.Join(name, "SKILL.md"))
+}
+
+func (m MapSource) Profile(name string) (skills.Doc, error) {
+	return m.lookup(filepath.Join(name, "profile.md"))
+}
+
+func (m MapSource) lookup(path string) (skills.Doc, error) {
+	content, ok := m[path]
+	if !ok {
+		return skills.Doc{}, skills.ErrNotFound
+	}
+	return skills.Doc{Path: path, Content: content}, nil
+}
+
+// ----------------------------------------------------------------------
+// FilesystemSource
+// ----------------------------------------------------------------------
+
+func TestFilesystemSourceUniversalReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "_universal.md"), []byte("UNIV"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	src := skills.FilesystemSource{Root: dir}
+	got, err := src.Universal()
+	if err != nil {
+		t.Fatalf("Universal: %v", err)
+	}
+	if got.Content != "UNIV" {
+		t.Errorf("Universal content = %q, want %q", got.Content, "UNIV")
+	}
+	if got.Path != "_universal.md" {
+		t.Errorf("Universal path = %q, want %q", got.Path, "_universal.md")
+	}
+}
+
+func TestFilesystemSourceSkillReadsNestedFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "github"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "github", "SKILL.md"), []byte("SKILL"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	src := skills.FilesystemSource{Root: dir}
+	got, err := src.Skill("github")
+	if err != nil {
+		t.Fatalf("Skill: %v", err)
+	}
+	if got.Content != "SKILL" {
+		t.Errorf("Skill content = %q, want %q", got.Content, "SKILL")
+	}
+}
+
+func TestFilesystemSourceMissingReturnsErrNotFound(t *testing.T) {
+	src := skills.FilesystemSource{Root: t.TempDir()}
+	_, err := src.Universal()
+	if !errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// EmbeddedSource — sanity checks against the bundled dotfiles content
+// ----------------------------------------------------------------------
+
+func TestEmbeddedSourceUniversalContainsExpectedSentinel(t *testing.T) {
+	src := skills.EmbeddedSource{}
+	doc, err := src.Universal()
+	if err != nil {
+		t.Fatalf("Universal: %v", err)
+	}
+	// Distinctive H2 heading from claude/profiles/_universal.md;
+	// unique vs github/SKILL.md and github/profile.md.
+	const sentinel = "Operator Intent Required"
+	if !strings.Contains(doc.Content, sentinel) {
+		t.Errorf("Universal content missing sentinel %q", sentinel)
+	}
+}
+
+func TestEmbeddedSourceGitHubSkillContainsExpectedSentinel(t *testing.T) {
+	src := skills.EmbeddedSource{}
+	doc, err := src.Skill("github")
+	if err != nil {
+		t.Fatalf("Skill(github): %v", err)
+	}
+	// Distinctive prose from claude/skills/github/SKILL.md commit-conventions
+	// section; unique vs the universal/profile addenda.
+	const sentinel = "Conventional commits format"
+	if !strings.Contains(doc.Content, sentinel) {
+		t.Errorf("github SKILL.md missing sentinel %q", sentinel)
+	}
+}
+
+func TestEmbeddedSourceGitHubProfileContainsExpectedSentinel(t *testing.T) {
+	src := skills.EmbeddedSource{}
+	doc, err := src.Profile("github")
+	if err != nil {
+		t.Fatalf("Profile(github): %v", err)
+	}
+	// Distinctive PR Lifecycle Gates rule from
+	// claude/profiles/github.md; unique vs SKILL.md and universal.
+	const sentinel = "must not be exposed as callable tools"
+	if !strings.Contains(doc.Content, sentinel) {
+		t.Errorf("github profile.md missing sentinel %q", sentinel)
+	}
+}
+
+func TestEmbeddedSourceUnknownSkillReturnsErrNotFound(t *testing.T) {
+	src := skills.EmbeddedSource{}
+	_, err := src.Skill("nonexistent-skill")
+	if !errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestEmbeddedSourceSkillWithoutProfileReturnsErrNotFound(t *testing.T) {
+	// github currently has both SKILL.md AND profile.md, so this test
+	// pins the contract: when a skill has no profile, Profile() returns
+	// ErrNotFound. Once a skill ships without a profile addendum, this
+	// test exercises that path.
+	src := skills.EmbeddedSource{}
+	_, err := src.Profile("nonexistent-skill")
+	if !errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// FallbackSource
+// ----------------------------------------------------------------------
+
+func TestFallbackSourceUsesEmbeddedWhenFilesystemMissing(t *testing.T) {
+	src := skills.FallbackSource{
+		Primary:   skills.FilesystemSource{Root: "/nonexistent/path"},
+		Secondary: skills.EmbeddedSource{},
+	}
+	doc, err := src.Skill("github")
+	if err != nil {
+		t.Fatalf("Skill(github): %v", err)
+	}
+	const sentinel = "Conventional commits format"
+	if !strings.Contains(doc.Content, sentinel) {
+		t.Errorf("fallback to embedded missing sentinel %q", sentinel)
+	}
+}
+
+func TestFallbackSourceUsesFilesystemWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "github"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "github", "SKILL.md"), []byte("OVERRIDE-SENTINEL"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	src := skills.FallbackSource{
+		Primary:   skills.FilesystemSource{Root: dir},
+		Secondary: skills.EmbeddedSource{},
+	}
+	doc, err := src.Skill("github")
+	if err != nil {
+		t.Fatalf("Skill(github): %v", err)
+	}
+	if doc.Content != "OVERRIDE-SENTINEL" {
+		t.Errorf("filesystem primary should win, got %q", doc.Content)
+	}
+}
+
+func TestFallbackSourcePropagatesNonNotFoundErrors(t *testing.T) {
+	// If the primary returns a real error (not ErrNotFound), it should
+	// short-circuit rather than fall through to the secondary. This
+	// avoids masking permission-denied / real I/O errors.
+	src := skills.FallbackSource{
+		Primary:   errSource{err: errors.New("permission denied")},
+		Secondary: skills.EmbeddedSource{},
+	}
+	_, err := src.Skill("github")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected non-ErrNotFound to short-circuit, got wrapped ErrNotFound")
+	}
+}
+
+// errSource is a test-only Source that always returns a fixed error.
+type errSource struct{ err error }
+
+func (e errSource) Universal() (skills.Doc, error)       { return skills.Doc{}, e.err }
+func (e errSource) Skill(name string) (skills.Doc, error) { return skills.Doc{}, e.err }
+func (e errSource) Profile(name string) (skills.Doc, error) {
+	return skills.Doc{}, e.err
+}

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -151,6 +151,72 @@ func TestEmbeddedSourceSkillWithoutProfileReturnsErrNotFound(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
+// Skill name validation — applied at Source.Skill / Source.Profile
+// entry points across all impls. Defence-in-depth against path-traversal
+// even though skill names are operator-controlled via crew.yaml today.
+// ----------------------------------------------------------------------
+
+func TestSourceRejectsTraversalSkillName(t *testing.T) {
+	cases := []string{
+		"../etc",
+		"../../../etc/passwd",
+		"foo/../bar",
+		"/absolute",
+		"foo/bar",
+		`foo\bar`,
+		"..",
+		".",
+		".hidden",
+		"",
+		"Github",
+		"my_skill",
+		"foo bar",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			fsSrc := skills.FilesystemSource{Root: t.TempDir()}
+			if _, err := fsSrc.Skill(name); !errors.Is(err, skills.ErrInvalidSkillName) {
+				t.Errorf("FilesystemSource.Skill(%q): expected ErrInvalidSkillName, got %v", name, err)
+			}
+			if _, err := fsSrc.Profile(name); !errors.Is(err, skills.ErrInvalidSkillName) {
+				t.Errorf("FilesystemSource.Profile(%q): expected ErrInvalidSkillName, got %v", name, err)
+			}
+
+			emSrc := skills.EmbeddedSource{}
+			if _, err := emSrc.Skill(name); !errors.Is(err, skills.ErrInvalidSkillName) {
+				t.Errorf("EmbeddedSource.Skill(%q): expected ErrInvalidSkillName, got %v", name, err)
+			}
+			if _, err := emSrc.Profile(name); !errors.Is(err, skills.ErrInvalidSkillName) {
+				t.Errorf("EmbeddedSource.Profile(%q): expected ErrInvalidSkillName, got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestSourceAcceptsValidSkillName(t *testing.T) {
+	cases := []string{
+		"github",
+		"kubernetes",
+		"my-skill",
+		"k8s",
+		"skill1",
+		"a",
+		"foo-bar-baz",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			// The skill won't exist in the embedded source, so the
+			// expected error is ErrNotFound, NOT ErrInvalidSkillName —
+			// proving validation accepts the name and lookup proceeds.
+			_, err := skills.EmbeddedSource{}.Skill(name)
+			if errors.Is(err, skills.ErrInvalidSkillName) {
+				t.Errorf("Skill(%q): unexpectedly rejected as invalid", name)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------
 // FallbackSource
 // ----------------------------------------------------------------------
 

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -294,7 +294,13 @@ func TestFallbackSourceUsesFilesystemWhenPresent(t *testing.T) {
 func TestFallbackSourceRejectsNilPrimaryOrSecondary(t *testing.T) {
 	// Misconfiguration (forgetting Primary or Secondary at construction
 	// time) should surface as ErrNilSource, not panic at the closure
-	// dereference inside tryFallback.
+	// dereference inside tryFallback. Covers BOTH the bare-nil and
+	// typed-nil shapes — the latter is the Go gotcha where a non-nil
+	// interface holds a nil pointer (`var p *FilesystemSource = nil`)
+	// and would otherwise pass an `== nil` check yet panic on call.
+	var typedNilFS *skills.FilesystemSource     // nil pointer
+	var typedNilSrc skills.Source = typedNilFS  // typed-nil in interface
+
 	cases := []struct {
 		name string
 		src  skills.FallbackSource
@@ -302,6 +308,8 @@ func TestFallbackSourceRejectsNilPrimaryOrSecondary(t *testing.T) {
 		{"nil primary", skills.FallbackSource{Primary: nil, Secondary: skills.EmbeddedSource{}}},
 		{"nil secondary", skills.FallbackSource{Primary: skills.EmbeddedSource{}, Secondary: nil}},
 		{"both nil", skills.FallbackSource{}},
+		{"typed-nil primary", skills.FallbackSource{Primary: typedNilSrc, Secondary: skills.EmbeddedSource{}}},
+		{"typed-nil secondary", skills.FallbackSource{Primary: skills.EmbeddedSource{}, Secondary: typedNilSrc}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -3,6 +3,7 @@ package skills_test
 import (
 	"errors"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +15,10 @@ import (
 // canonical relative path (e.g. "_universal.md", "github/SKILL.md").
 // Used by Compose tests to inject precise document content without
 // filesystem or embed.FS dependencies.
+//
+// Keys are slash-separated (path.Join, not filepath.Join) to match the
+// canonical Doc.Path contract — same shape as the production sources
+// regardless of host OS.
 type MapSource map[string]string
 
 func (m MapSource) Universal() (skills.Doc, error) {
@@ -21,11 +26,11 @@ func (m MapSource) Universal() (skills.Doc, error) {
 }
 
 func (m MapSource) Skill(name string) (skills.Doc, error) {
-	return m.lookup(filepath.Join(name, "SKILL.md"))
+	return m.lookup(path.Join(name, "SKILL.md"))
 }
 
 func (m MapSource) Profile(name string) (skills.Doc, error) {
-	return m.lookup(filepath.Join(name, "profile.md"))
+	return m.lookup(path.Join(name, "profile.md"))
 }
 
 func (m MapSource) lookup(path string) (skills.Doc, error) {


### PR DESCRIPTION
## Summary

First sub-PR of [#148](https://github.com/Klazomenai/bridge/issues/148) (Source/Compose skill loader epic). Pure additive: introduces a new `internal/crew/skills/` package with the loader/compose API surface and embedded fallback fixtures. **No callers** — the existing `if id == "chips"` gate in `internal/crew/registry.go` continues to wins at runtime.

The split into 5 sub-PRs (a → e, this is **a**) keeps each diff small enough for a single Copilot review cycle without state explosion across stacked branches.

## What's in this PR

### `internal/crew/skills/` package

- **`loader.go`** — `Source` interface + three implementations:
  - `FilesystemSource{Root}` — reads `<Root>/_universal.md`, `<Root>/<name>/SKILL.md`, `<Root>/<name>/profile.md`
  - `EmbeddedSource{}` — `//go:embed embedded/*.md embedded/*/*.md`
  - `FallbackSource{Primary, Secondary}` — primary `ErrNotFound` falls through to secondary; non-`ErrNotFound` short-circuits (no permission-denied masking)
  - `Doc{Path, Content}` + `ErrNotFound` sentinel
- **`compose.go`** — `Compose(persona, skills []string, src Source) (string, error)` with sentinels `ErrEmptyPersona` + `ErrUniversalRequired`. Empty `skills` returns persona unchanged (no universal section). Non-empty produces a persona/universal/skill/profile-section render with `\n\n` boundaries.
- **`embedded.go`** — the `//go:embed` directive
- **`embedded/`** — frozen mirror of dotfiles main HEAD: `_universal.md`, `github/SKILL.md`, `github/profile.md`. Drift CI in sub-PR **e** will guard staleness vs `DOTFILES_REF`.

### Tests

- `loader_test.go` — `FilesystemSource` (read/missing/nested), `EmbeddedSource` (sentinel checks for universal/SKILL/profile + unknown-skill), `FallbackSource` (primary-wins / fallback / non-`ErrNotFound`-short-circuit). Includes test-only `MapSource` for the compose tests.
- `compose_test.go` — empty-persona, no-skills, ordering, boundary-markers, missing-universal/skill/profile, multi-skill declaration order, persona trim/separator semantics.

20 new unit tests total. All currently passing.

## Title-casing note

Skill heading title-casing is first-rune uppercase ("github" → "Github"). Proper-noun rendering ("GitHub") deferred to a future `SkillMetadata{DisplayName}` field — accepted cosmetic regression for the epic per design ratification.

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./...` clean
- [x] `CGO_ENABLED=0 go test -tags goolm ./internal/crew/skills/...` — all 20 tests pass
- [x] `CGO_ENABLED=0 go test -tags goolm ./internal/...` — all packages still green (zero callers added in this PR)

Refs #148 #151
