### PR TITLE
refactor(tools): extract redaction package + audit-log seam 🔐

### DIFF
--- a/internal/orchestrator/toolloop.go
+++ b/internal/orchestrator/toolloop.go
@@ -168,7 +168,12 @@ func (o *Orchestrator) executeToolCalls(ctx context.Context, content []anthropic
 			continue
 		}
 
-		meta := tools.SandboxMeta{CrewID: crewID, RoomID: roomID, ToolName: block.Name}
+		meta := tools.SandboxMeta{
+			CrewID:   crewID,
+			RoomID:   roomID,
+			ToolName: block.Name,
+			Mutation: tools.IsMutation(tool),
+		}
 		result, isError := tools.ExecuteWithSandbox(ctx, tool, block.Input, o.sandboxCfg, meta)
 
 		// Detect delegation sentinel — only from the delegate_to_crew tool.

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"klazomenai/bridge/internal/tools/redact"
 )
 
 // ExecFn executes a command and returns its standard output (stdout).
@@ -48,9 +50,9 @@ func (a RepoAllowlist) Check(org, repo string) error {
 var SanitiseOutputForTest = sanitiseOutput
 
 // sanitiseOutput strips the GITHUB_TOKEN value from output if present.
+// Thin wrapper over redact.Redact so existing chips call sites keep
+// their two-argument shape; the package-level redactor is shared with
+// the audit-log path (sandbox.go).
 func sanitiseOutput(output, token string) string {
-	if token == "" {
-		return output
-	}
-	return strings.ReplaceAll(output, token, "[REDACTED]")
+	return redact.Redact(output, token)
 }

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -10,7 +10,10 @@
 // per-package redaction layered on top of Redact (e.g. internal/tools/maren).
 package redact
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // Sentinel is the replacement string substituted for each redacted secret.
 const Sentinel = "[REDACTED]"
@@ -19,13 +22,27 @@ const Sentinel = "[REDACTED]"
 // by Sentinel. Empty secrets are skipped (so callers can pass through
 // unset configuration values without conditional logic).
 //
-// Redact is a single-pass replacement per secret: if multiple secrets
-// share a substring, ordering matters — pass the longer secret first.
+// Internally sorts the secrets by descending length before replacement
+// so callers do NOT need to reason about overlap ordering. Without
+// this guarantee, ["foo", "foobar"] passed in caller-supplied order
+// would replace "foo" first and leave "[REDACTED]bar" — a partial
+// secret leak. The internal sort ensures the longest match always
+// wins regardless of caller order.
 func Redact(input string, secrets ...string) string {
-	for _, secret := range secrets {
-		if secret == "" {
-			continue
+	if len(secrets) == 0 {
+		return input
+	}
+	// Defensive copy: filter empties + leave caller's slice untouched.
+	filtered := make([]string, 0, len(secrets))
+	for _, s := range secrets {
+		if s != "" {
+			filtered = append(filtered, s)
 		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return len(filtered[i]) > len(filtered[j])
+	})
+	for _, secret := range filtered {
 		input = strings.ReplaceAll(input, secret, Sentinel)
 	}
 	return input

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -1,0 +1,32 @@
+// Package redact provides token redaction primitives for tool output
+// before it reaches the model, the user, or the audit log.
+//
+// The package is intentionally minimal: a variadic Redact function that
+// substitutes a sentinel for each known secret. Callers are responsible
+// for deciding which strings to treat as secrets — this package does
+// not detect tokens; it only redacts known ones.
+//
+// For structured redaction (e.g. kubectl YAML field stripping), see the
+// per-package redaction layered on top of Redact (e.g. internal/tools/maren).
+package redact
+
+import "strings"
+
+// Sentinel is the replacement string substituted for each redacted secret.
+const Sentinel = "[REDACTED]"
+
+// Redact returns input with every non-empty secret in secrets replaced
+// by Sentinel. Empty secrets are skipped (so callers can pass through
+// unset configuration values without conditional logic).
+//
+// Redact is a single-pass replacement per secret: if multiple secrets
+// share a substring, ordering matters — pass the longer secret first.
+func Redact(input string, secrets ...string) string {
+	for _, secret := range secrets {
+		if secret == "" {
+			continue
+		}
+		input = strings.ReplaceAll(input, secret, Sentinel)
+	}
+	return input
+}

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -67,3 +67,37 @@ func TestRedactRepeatedOccurrencesAllReplaced(t *testing.T) {
 		t.Errorf("expected 3 sentinel substitutions, got %q", out)
 	}
 }
+
+func TestRedactOverlappingSecretsLongerWinsRegardlessOfOrder(t *testing.T) {
+	// Without internal length-descending sort, the caller-supplied
+	// order ["foo", "foobar"] would match "foo" first (inside
+	// "foobar") and leave "[REDACTED]bar" — a partial secret leak.
+	// The internal sort guarantees the longest match wins, so both
+	// caller orderings produce identical output.
+	cases := []struct {
+		name    string
+		secrets []string
+	}{
+		{"shorter first", []string{"foo", "foobar"}},
+		{"longer first", []string{"foobar", "foo"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := redact.Redact("foo and foobar are secrets", tc.secrets...)
+			if strings.Contains(out, "foobar") {
+				t.Errorf("partial redaction left foobar: %q", out)
+			}
+			if strings.Contains(out, "foo ") {
+				t.Errorf("standalone foo not redacted: %q", out)
+			}
+			// A residual "bar" implies foobar's tail leaked through
+			// partial redaction.
+			if strings.Contains(out, "bar") {
+				t.Errorf("residual bar suffix (partial leak): %q", out)
+			}
+			if strings.Count(out, redact.Sentinel) != 2 {
+				t.Errorf("expected 2 sentinel substitutions, got %q", out)
+			}
+		})
+	}
+}

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -1,0 +1,69 @@
+package redact_test
+
+import (
+	"strings"
+	"testing"
+
+	"klazomenai/bridge/internal/tools/redact"
+)
+
+func TestRedactSingleSecretReplaced(t *testing.T) {
+	out := redact.Redact("token=ghp_abc123 user=root", "ghp_abc123")
+	if strings.Contains(out, "ghp_abc123") {
+		t.Errorf("raw secret leaked: %q", out)
+	}
+	if !strings.Contains(out, redact.Sentinel) {
+		t.Errorf("sentinel missing: %q", out)
+	}
+}
+
+func TestRedactMultipleSecretsReplaced(t *testing.T) {
+	out := redact.Redact(
+		"gh=ghp_abc123 ssh=AAAA-priv-key",
+		"ghp_abc123",
+		"AAAA-priv-key",
+	)
+	if strings.Contains(out, "ghp_abc123") || strings.Contains(out, "AAAA-priv-key") {
+		t.Errorf("raw secret leaked: %q", out)
+	}
+	if strings.Count(out, redact.Sentinel) != 2 {
+		t.Errorf("expected 2 sentinel substitutions, got %q", out)
+	}
+}
+
+func TestRedactEmptySecretIsSkipped(t *testing.T) {
+	// Empty secret would otherwise match every position via
+	// strings.ReplaceAll — explicitly skipped to allow unset config
+	// values to pass through without conditional logic at the call site.
+	in := "no-secrets-here"
+	out := redact.Redact(in, "")
+	if out != in {
+		t.Errorf("empty secret altered output: %q → %q", in, out)
+	}
+}
+
+func TestRedactNoSecretsReturnsInputUnchanged(t *testing.T) {
+	in := "plain text"
+	out := redact.Redact(in)
+	if out != in {
+		t.Errorf("no-args call altered output: %q → %q", in, out)
+	}
+}
+
+func TestRedactSecretNotPresentReturnsInputUnchanged(t *testing.T) {
+	in := "no token here"
+	out := redact.Redact(in, "ghp_does_not_appear")
+	if out != in {
+		t.Errorf("missing-secret call altered output: %q → %q", in, out)
+	}
+}
+
+func TestRedactRepeatedOccurrencesAllReplaced(t *testing.T) {
+	out := redact.Redact("ghp_xyz one ghp_xyz two ghp_xyz", "ghp_xyz")
+	if strings.Contains(out, "ghp_xyz") {
+		t.Errorf("residual secret occurrence: %q", out)
+	}
+	if strings.Count(out, redact.Sentinel) != 3 {
+		t.Errorf("expected 3 sentinel substitutions, got %q", out)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -26,6 +26,26 @@ type ToolDefinition interface {
 	Execute(ctx context.Context, input json.RawMessage) (string, error)
 }
 
+// MutationAware is an optional interface a tool may implement to declare
+// whether its invocation mutates external state. The audit log emits a
+// `mutation` field for every invocation; tools that do NOT implement this
+// interface are conservatively treated as read-only (mutation=false).
+//
+// Write tools (e.g. a future gh_issue_close) should implement Mutation()
+// returning true so the audit log surfaces an irreversible action.
+type MutationAware interface {
+	Mutation() bool
+}
+
+// IsMutation reports whether tool t represents a state-mutating operation.
+// Returns false when t does not implement MutationAware.
+func IsMutation(t ToolDefinition) bool {
+	if m, ok := t.(MutationAware); ok {
+		return m.Mutation()
+	}
+	return false
+}
+
 // Registry holds all registered tools and provides lookup by name and crew.
 type Registry struct {
 	mu    sync.RWMutex

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	"klazomenai/bridge/internal/tools/redact"
 )
 
 const (
@@ -23,10 +25,33 @@ type SandboxConfig struct {
 }
 
 // SandboxMeta carries per-invocation context for structured audit logging.
+//
+// Fields:
+//   - CrewID, RoomID, ToolName — identifying context for the invocation
+//   - Mutation — whether the tool mutates external state (set by callers
+//     via tools.IsMutation(tool))
+//   - Logger — destination for the structured audit + execution events
+//     emitted by ExecuteWithSandbox; nil falls back to slog.Default()
+//   - Secrets — values to redact from the audit log's argv field via
+//     redact.Redact (e.g. GITHUB_TOKEN); empty entries are skipped
 type SandboxMeta struct {
 	CrewID   string
 	RoomID   string
 	ToolName string
+	Mutation bool
+	Logger   *slog.Logger
+	Secrets  []string
+}
+
+// logger returns the SandboxMeta's logger, falling back to slog.Default()
+// when nil. Callers within this package use this helper instead of the
+// package-level slog.* functions so per-invocation logger injection works
+// for tests and future per-room routing.
+func (m SandboxMeta) logger() *slog.Logger {
+	if m.Logger != nil {
+		return m.Logger
+	}
+	return slog.Default()
 }
 
 // DefaultSandboxConfig returns a SandboxConfig with production defaults.
@@ -53,6 +78,20 @@ func ExecuteWithSandbox(ctx context.Context, tool ToolDefinition, input json.Raw
 	if cfg.MaxOutputLen <= 0 {
 		cfg.MaxOutputLen = DefaultMaxOutputLen
 	}
+
+	logger := meta.logger()
+
+	// Audit record — emitted before execution so an in-flight panic or
+	// timeout still leaves a trail of the attempted invocation. The
+	// argv field is redacted using meta.Secrets to keep tokens out of
+	// the log destination (stdout, journald, downstream collectors).
+	logger.Info("audit: tool invoked",
+		"tool", meta.ToolName,
+		"crew", meta.CrewID,
+		"room", meta.RoomID,
+		"mutation", meta.Mutation,
+		"argv_redacted", redact.Redact(string(input), meta.Secrets...),
+	)
 
 	start := time.Now()
 
@@ -83,7 +122,7 @@ func ExecuteWithSandbox(ctx context.Context, tool ToolDefinition, input json.Raw
 			}
 		}
 
-		slog.Warn("sandbox: tool execution failed",
+		logger.Warn("sandbox: tool execution failed",
 			"tool", meta.ToolName, "crew", meta.CrewID,
 			"room", meta.RoomID, "duration_ms", elapsed.Milliseconds(),
 			"err", execErr)
@@ -99,7 +138,7 @@ func ExecuteWithSandbox(ctx context.Context, tool ToolDefinition, input json.Raw
 		}
 	}
 
-	slog.Info("sandbox: tool executed",
+	logger.Info("sandbox: tool executed",
 		"tool", meta.ToolName, "crew", meta.CrewID,
 		"room", meta.RoomID, "duration_ms", elapsed.Milliseconds(),
 		"output_len_bytes", len(output))

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -62,6 +62,25 @@ func DefaultSandboxConfig() SandboxConfig {
 	}
 }
 
+// truncateForLog returns s capped at maxRunes runes, with a "\n[truncated]"
+// marker appended when truncation occurred. Fast-path: byte length <=
+// maxRunes implies rune count <= maxRunes (UTF-8 invariant), so the
+// rune-conversion is only paid on the uncommon long-input path.
+//
+// Used by ExecuteWithSandbox at three sites: error messages, tool
+// output, and the audit log's argv_redacted field. Centralised so the
+// rune-safety invariant cannot drift across sites.
+func truncateForLog(s string, maxRunes int) string {
+	if len(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes]) + "\n[truncated]"
+}
+
 // ExecuteWithSandbox runs a tool within a cooperative timeout, recovers panics,
 // caps output, and emits structured audit logs. Returns the result string and
 // whether the result represents an error.
@@ -84,13 +103,16 @@ func ExecuteWithSandbox(ctx context.Context, tool ToolDefinition, input json.Raw
 	// Audit record — emitted before execution so an in-flight panic or
 	// timeout still leaves a trail of the attempted invocation. The
 	// argv field is redacted using meta.Secrets to keep tokens out of
-	// the log destination (stdout, journald, downstream collectors).
+	// the log destination (stdout, journald, downstream collectors)
+	// AND truncated to MaxOutputLen so a tool with a giant input
+	// payload cannot blow up downstream collectors or smuggle large
+	// non-secret-but-sensitive content past the redaction layer.
 	logger.Info("audit: tool invoked",
 		"tool", meta.ToolName,
 		"crew", meta.CrewID,
 		"room", meta.RoomID,
 		"mutation", meta.Mutation,
-		"argv_redacted", redact.Redact(string(input), meta.Secrets...),
+		"argv_redacted", truncateForLog(redact.Redact(string(input), meta.Secrets...), cfg.MaxOutputLen),
 	)
 
 	start := time.Now()
@@ -113,14 +135,9 @@ func ExecuteWithSandbox(ctx context.Context, tool ToolDefinition, input json.Raw
 	elapsed := time.Since(start)
 
 	if execErr != nil {
-		errMsg := execErr.Error()
-		// Apply the same rune-based truncation to error output to prevent
-		// tools from bypassing MaxOutputLen via oversized error messages.
-		if len(errMsg) > cfg.MaxOutputLen {
-			if runes := []rune(errMsg); len(runes) > cfg.MaxOutputLen {
-				errMsg = string(runes[:cfg.MaxOutputLen]) + "\n[truncated]"
-			}
-		}
+		// Truncate error output rune-safely so tools cannot bypass
+		// MaxOutputLen via oversized error messages.
+		errMsg := truncateForLog(execErr.Error(), cfg.MaxOutputLen)
 
 		logger.Warn("sandbox: tool execution failed",
 			"tool", meta.ToolName, "crew", meta.CrewID,
@@ -129,14 +146,7 @@ func ExecuteWithSandbox(ctx context.Context, tool ToolDefinition, input json.Raw
 		return fmt.Sprintf("tool error: %s", errMsg), true
 	}
 
-	// Fast path: byte length <= cap means rune count must also be <= cap
-	// (UTF-8 invariant). Only pay for rune conversion on the uncommon
-	// long-output path.
-	if len(output) > cfg.MaxOutputLen {
-		if runes := []rune(output); len(runes) > cfg.MaxOutputLen {
-			output = string(runes[:cfg.MaxOutputLen]) + "\n[truncated]"
-		}
-	}
+	output = truncateForLog(output, cfg.MaxOutputLen)
 
 	logger.Info("sandbox: tool executed",
 		"tool", meta.ToolName, "crew", meta.CrewID,

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -13,6 +13,7 @@ import (
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 
 	"klazomenai/bridge/internal/tools"
+	"klazomenai/bridge/internal/tools/redact"
 )
 
 // auditLogger returns a logger that writes JSON-formatted records into
@@ -248,8 +249,8 @@ func TestAuditRecordRedactsSecrets(t *testing.T) {
 	if strings.Contains(out, secret) {
 		t.Errorf("raw secret leaked into audit log:\n%s", out)
 	}
-	if !strings.Contains(out, "[REDACTED]") {
-		t.Errorf("expected [REDACTED] sentinel in audit log:\n%s", out)
+	if !strings.Contains(out, redact.Sentinel) {
+		t.Errorf("expected %s sentinel in audit log:\n%s", redact.Sentinel, out)
 	}
 }
 

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -1,9 +1,11 @@
 package tools_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +14,15 @@ import (
 
 	"klazomenai/bridge/internal/tools"
 )
+
+// auditLogger returns a logger that writes JSON-formatted records into
+// the returned buffer. Used by audit-record tests to capture and assert
+// against the structured fields ExecuteWithSandbox emits.
+func auditLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	return logger, buf
+}
 
 // testTool is a configurable tool for sandbox tests.
 type testTool struct {
@@ -172,5 +183,117 @@ func TestExecuteWithSandbox_ErrorMessageTruncated(t *testing.T) {
 	}
 	if !strings.HasPrefix(result, "tool error: ") {
 		t.Errorf("expected 'tool error: ' prefix, got %q", result[:30])
+	}
+}
+
+// ----------------------------------------------------------------------
+// Audit record — covers the slog.Info("audit: tool invoked", ...) line
+// ExecuteWithSandbox emits before tool execution, including:
+//   - structured-field shape (tool/crew/room/mutation/argv_redacted)
+//   - per-call Logger injection via SandboxMeta.Logger
+//   - secret redaction via SandboxMeta.Secrets + redact.Redact
+//   - rune-safe truncation of argv_redacted at MaxOutputLen
+// ----------------------------------------------------------------------
+
+func TestAuditRecordEmittedOnInvocation(t *testing.T) {
+	logger, buf := auditLogger()
+	tool := &testTool{name: "ok", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "result", nil
+	}}
+	meta := tools.SandboxMeta{
+		CrewID:   "chips",
+		RoomID:   "!room:localhost",
+		ToolName: "test_tool",
+		Mutation: false,
+		Logger:   logger,
+	}
+	input := json.RawMessage(`{"org":"klazomenai","repo":"bridge"}`)
+
+	tools.ExecuteWithSandbox(context.Background(), tool, input, tools.DefaultSandboxConfig(), meta)
+
+	out := buf.String()
+	for _, want := range []string{
+		`"msg":"audit: tool invoked"`,
+		`"tool":"test_tool"`,
+		`"crew":"chips"`,
+		`"room":"!room:localhost"`,
+		`"mutation":false`,
+		`"argv_redacted":"{\"org\":\"klazomenai\",\"repo\":\"bridge\"}"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("audit log missing field %q\nfull buffer:\n%s", want, out)
+		}
+	}
+}
+
+func TestAuditRecordRedactsSecrets(t *testing.T) {
+	logger, buf := auditLogger()
+	tool := &testTool{name: "ok", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	}}
+	const secret = "ghp_supersecret_token_value"
+	meta := tools.SandboxMeta{
+		CrewID:   "chips",
+		RoomID:   "!room:localhost",
+		ToolName: "test_tool",
+		Logger:   logger,
+		Secrets:  []string{secret},
+	}
+	// Input contains the literal secret embedded in a JSON string.
+	input := json.RawMessage(fmt.Sprintf(`{"token":%q}`, secret))
+
+	tools.ExecuteWithSandbox(context.Background(), tool, input, tools.DefaultSandboxConfig(), meta)
+
+	out := buf.String()
+	if strings.Contains(out, secret) {
+		t.Errorf("raw secret leaked into audit log:\n%s", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] sentinel in audit log:\n%s", out)
+	}
+}
+
+func TestAuditRecordTruncatesLargeArgv(t *testing.T) {
+	logger, buf := auditLogger()
+	tool := &testTool{name: "ok", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	}}
+	cfg := tools.SandboxConfig{Timeout: 30 * time.Second, MaxOutputLen: 100}
+	meta := tools.SandboxMeta{
+		CrewID:   "chips",
+		RoomID:   "!room:localhost",
+		ToolName: "test_tool",
+		Logger:   logger,
+	}
+	input := json.RawMessage(strings.Repeat("x", 5000))
+
+	tools.ExecuteWithSandbox(context.Background(), tool, input, cfg, meta)
+
+	out := buf.String()
+	if !strings.Contains(out, "[truncated]") {
+		t.Errorf("expected [truncated] marker for oversized argv:\n%s", out[:200])
+	}
+}
+
+func TestAuditRecordUsesDefaultLoggerWhenMetaLoggerNil(t *testing.T) {
+	// Without injection, ExecuteWithSandbox falls back to slog.Default().
+	// We cannot intercept slog.Default() output portably, but we CAN
+	// assert that a nil Logger field doesn't panic and the call still
+	// completes — pinning the contract that Logger is optional.
+	tool := &testTool{name: "ok", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	}}
+	meta := tools.SandboxMeta{
+		CrewID:   "chips",
+		RoomID:   "!room:localhost",
+		ToolName: "test_tool",
+		Logger:   nil, // explicit nil — falls back to slog.Default
+	}
+	result, isError := tools.ExecuteWithSandbox(context.Background(), tool, nil, tools.DefaultSandboxConfig(), meta)
+	if isError {
+		t.Errorf("unexpected error: %s", result)
+	}
+	if result != "ok" {
+		t.Errorf("expected result=ok, got %q", result)
 	}
 }

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -183,7 +183,7 @@ func TestExecuteWithSandbox_ErrorMessageTruncated(t *testing.T) {
 		t.Error("expected truncation of oversized error message")
 	}
 	if !strings.HasPrefix(result, "tool error: ") {
-		t.Errorf("expected 'tool error: ' prefix, got %q", result[:30])
+		t.Errorf("expected 'tool error: ' prefix, got %q", result)
 	}
 }
 
@@ -272,7 +272,10 @@ func TestAuditRecordTruncatesLargeArgv(t *testing.T) {
 
 	out := buf.String()
 	if !strings.Contains(out, "[truncated]") {
-		t.Errorf("expected [truncated] marker for oversized argv:\n%s", out[:200])
+		// Dump full buffer rather than slicing — a regression that
+		// returns short output must surface a clean failure, not a
+		// slice panic that masks the real cause.
+		t.Errorf("expected [truncated] marker for oversized argv:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Second sub-PR of [#148](https://github.com/Klazomenai/bridge/issues/148) (Source/Compose skill loader epic). Two small, decoupled additions that the L2 enforcement tests in sub-PR **d** (#154) will rely on. Behaviour-preserving for existing tools — both changes install seams without altering runtime output paths.

## What's in this PR

### Commit 1: `redact` package extraction

Lifts the GITHUB_TOKEN substring redaction out of `internal/tools/chips/exec.go` into a new `internal/tools/redact/` package with a variadic API:

```go
redact.Redact(input string, secrets ...string) string
```

The variadic shape lets the audit-log path (commit 2) redact multiple distinct secrets in a single call (e.g. GITHUB_TOKEN + future SSH key material) without per-call branching. A package-level `Sentinel` (`"[REDACTED]"`) replaces the previous inline literal.

`chips/exec.go`'s `sanitiseOutput` stays as a thin wrapper around `redact.Redact` so the eight chips tools and the `SanitiseOutputForTest` alias keep their two-argument call shape — zero call-site churn.

`internal/tools/maren/kubectl_get.go` has its own `sanitiseOutput` (different signature, structured kubectl YAML/JSON field redaction) — intentionally NOT extracted; different semantic.

### Commit 2: Audit-log seam

Three internal additions that establish the structured-audit surface needed for sub-PR **d**'s `TestAuditRecordEmittedOnWrite` and `TestAuditRecordRedactsTokens`:

- **`MutationAware` optional interface** (`internal/tools/registry.go`) — tools that mutate external state opt in by implementing `Mutation() bool`. Helper `IsMutation(t)` returns `false` when not implemented, so existing read-only tools (the entire current chips set: `gh_issue_list`, `gh_pr_view`, etc.) need no change.
- **`SandboxMeta` gains three fields** (`internal/tools/sandbox.go`):
  - `Mutation bool` — populated by callers from `IsMutation(tool)`
  - `Logger *slog.Logger` — destination for audit + execution events; nil falls back to `slog.Default()`. Per-call seam (no global mutation), so concurrent tests can each assert against their own buffer.
  - `Secrets []string` — values to redact from the audit log's `argv_redacted` field via `redact.Redact`. Empty entries are skipped.
- **New `slog.Info("audit: tool invoked", ...)` line** at the start of `ExecuteWithSandbox` (BEFORE the panic-recovery block) so an in-flight panic, timeout, or hang still leaves a trail of the attempted invocation. Fields: `tool`, `crew`, `room`, `mutation`, `argv_redacted`. The existing "sandbox: tool executed" / "sandbox: tool execution failed" lines stay — they describe the OUTCOME; the new audit line describes the ATTEMPT.

`internal/orchestrator/toolloop.go`'s per-block `SandboxMeta` construction now populates `Mutation: tools.IsMutation(tool)`. Logger and Secrets remain zero values for this PR — wiring the production GITHUB_TOKEN into Secrets is a future commit's wiring concern (the seam exists; nothing flows through it outside tests).

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./...` clean
- [x] `CGO_ENABLED=0 go test -tags goolm ./internal/tools/redact/...` — 6 tests pass (single secret, multi-secret, empty-skip, no-args, not-present, repeated occurrences)
- [x] `CGO_ENABLED=0 go test -tags goolm ./internal/tools/chips/...` — all chips tests still pass via the `sanitiseOutput` wrapper
- [x] `CGO_ENABLED=0 go test -tags goolm ./internal/...` — all 14 packages green (including the new `internal/tools/redact`)

Refs #148 #152
