### PR TITLE
test(tools): close coverage gaps from #152 🧪

### DIFF
--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -170,3 +170,43 @@ func TestNames(t *testing.T) {
 		t.Errorf("expected alpha and beta in names, got %v", names)
 	}
 }
+
+// mutatingTool implements MutationAware returning a configurable bool.
+// Used by TestIsMutation to exercise both branches of the helper.
+type mutatingTool struct {
+	stubTool
+	mutates bool
+}
+
+func (m *mutatingTool) Mutation() bool { return m.mutates }
+
+func TestIsMutation(t *testing.T) {
+	cases := []struct {
+		name string
+		tool tools.ToolDefinition
+		want bool
+	}{
+		{
+			name: "tool implementing MutationAware true",
+			tool: &mutatingTool{stubTool: stubTool{name: "writer"}, mutates: true},
+			want: true,
+		},
+		{
+			name: "tool implementing MutationAware false",
+			tool: &mutatingTool{stubTool: stubTool{name: "reader"}, mutates: false},
+			want: false,
+		},
+		{
+			name: "tool NOT implementing MutationAware (conservative default)",
+			tool: &stubTool{name: "legacy"},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tools.IsMutation(tc.tool); got != tc.want {
+				t.Errorf("IsMutation(%T) = %v, want %v", tc.tool, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -301,3 +301,36 @@ func TestAuditRecordUsesDefaultLoggerWhenMetaLoggerNil(t *testing.T) {
 		t.Errorf("expected result=ok, got %q", result)
 	}
 }
+
+// TestExecuteWithSandbox_ByteOverCapButRuneUnder exercises the multi-byte
+// UTF-8 edge in truncateForLog where len(s) > maxRunes (byte length
+// exceeds the cap) BUT len(runes) <= maxRunes (rune count within cap).
+// In that case the function must return the input UNTRUNCATED — the
+// rune-fast-path-then-fallback pattern relies on this branch existing
+// so genuinely-short multi-byte strings aren't falsely flagged as
+// oversized just because they happen to be encoded in 3-byte runes.
+//
+// Without this test the second `if len(runes) <= maxRunes { return s }`
+// branch in truncateForLog is unreached (the existing "utf8 rune
+// boundary" subtest exercises the truncation path with both byte AND
+// rune counts over the cap, missing this edge).
+func TestExecuteWithSandbox_ByteOverCapButRuneUnder(t *testing.T) {
+	// 4 runes of 日 = 12 bytes, 4 runes. With MaxOutputLen=10:
+	// byte length (12) > cap (10), rune count (4) <= cap (10).
+	tool := &testTool{name: "utf8edge", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {
+		return strings.Repeat("日", 4), nil
+	}}
+	cfg := tools.SandboxConfig{Timeout: 30 * time.Second, MaxOutputLen: 10}
+
+	result, isError := tools.ExecuteWithSandbox(context.Background(), tool, nil, cfg, testMeta())
+	if isError {
+		t.Fatal("unexpected error")
+	}
+	if strings.Contains(result, "[truncated]") {
+		t.Errorf("output with byte>cap but rune<=cap should NOT be truncated, got %q", result)
+	}
+	expected := strings.Repeat("日", 4)
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to merged PR #157, bringing PR2's two new symbols to 100% coverage. The acceptance criteria on [#152](https://github.com/Klazomenai/bridge/issues/152) required `IsMutation` and `truncateForLog` to EXIST and be wired in, but didn't require direct unit tests. Operator coverage gate ("100% or pause for discussion") flagged the gap; this PR closes it.

## Tests added

### `TestIsMutation` (`internal/tools/registry_test.go`)

Table-driven, three cases covering both branches of the type assertion in `IsMutation`:
- tool implements `MutationAware` returning `true` → `IsMutation` returns `true`
- tool implements `MutationAware` returning `false` → `IsMutation` returns `false`
- tool does NOT implement `MutationAware` → `IsMutation` returns `false` (conservative default — read-only is the safe assumption when the interface isn't declared)

New `mutatingTool` test helper composes `stubTool` with a configurable `Mutation() bool` method.

**`IsMutation` coverage: 0.0% → 100.0%**

### `TestExecuteWithSandbox_ByteOverCapButRuneUnder` (`internal/tools/sandbox_test.go`)

Exercises the multi-byte UTF-8 edge in `truncateForLog` where `len(s) > maxRunes` (byte length over cap) BUT `len(runes) <= maxRunes` (rune count within cap). The function must return the input UNTRUNCATED in that case — without this branch, genuinely-short multi-byte strings would be falsely flagged as oversized just because they happen to encode as 3-byte runes.

Test uses 4 runes of 日 (12 bytes total, 4 runes) with `MaxOutputLen=10`. The existing `"utf8 rune boundary"` subtest exercises the truncation path with both byte AND rune counts over cap, missing this edge.

**`truncateForLog` coverage: 83.3% → 100.0%**

## Net effect

`internal/tools` package coverage: **86.1% → 90.1%**. Remaining sub-100% items (`delegate.go`, `stub.go`) are pre-existing and out of scope.

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./...` clean
- [x] `CGO_ENABLED=0 go test -tags goolm -count=1 ./internal/...` — all 14 packages green
- [x] `go tool cover -func=...` confirms both targets at 100.0%

Refs #148 #152
