### PR TITLE
feat(crew): wire skills:[] schema into Compose (dual-path) 🎓

### DIFF
--- a/config/crew.yaml
+++ b/config/crew.yaml
@@ -73,6 +73,7 @@ crew:
     model: "claude-sonnet-4-6"
     verbosity: log-entry
     tools: [delegate_to_crew, gh_issue_list, gh_issue_view, gh_pr_list, gh_pr_view, gh_pr_checks, git_log, git_diff]
+    skills: [github]
     voice:
       model: TBD
       announces_as: "Chips:"

--- a/internal/crew/crew.go
+++ b/internal/crew/crew.go
@@ -11,6 +11,11 @@ type Crew interface {
 	AnnouncesAs() string
 	VoiceModel() string
 	Tools() []string
+	// Skills returns the names of skills declared in crew.yaml's
+	// `skills:` field. Each name resolves to a `<name>/SKILL.md` (and
+	// optional `<name>/profile.md`) in the skills source. Returns nil
+	// for crew with no skills declared.
+	Skills() []string
 }
 
 // BaseCrew holds the parsed crew member configuration.
@@ -24,6 +29,7 @@ type BaseCrew struct {
 	announcesAs  string
 	voiceModel   string
 	tools        []string
+	skills       []string
 }
 
 func (c *BaseCrew) ID() string           { return c.id }
@@ -40,5 +46,16 @@ func (c *BaseCrew) Tools() []string {
 	}
 	out := make([]string, len(c.tools))
 	copy(out, c.tools)
+	return out
+}
+
+// Skills returns a copy of the crew's declared skill names. Returns nil
+// when no skills are declared.
+func (c *BaseCrew) Skills() []string {
+	if len(c.skills) == 0 {
+		return nil
+	}
+	out := make([]string, len(c.skills))
+	copy(out, c.skills)
 	return out
 }

--- a/internal/crew/crew.go
+++ b/internal/crew/crew.go
@@ -16,30 +16,44 @@ type Crew interface {
 	// optional `<name>/profile.md`) in the skills source. Returns nil
 	// for crew with no skills declared.
 	Skills() []string
+	// ComposeOutput returns the skills.Compose-rendered prompt for crew
+	// with declared skills. Empty for crew without skills. Until the
+	// id-gate flip in #154, this is informational — SystemPrompt() is
+	// the runtime source of truth. After the flip, ComposeOutput will
+	// either be the source of truth or be removed entirely.
+	ComposeOutput() string
 }
 
 // BaseCrew holds the parsed crew member configuration.
+//
+// composeOutput holds the skills.Compose-rendered prompt for crew with
+// declared skills, populated by LoadWithSource alongside the
+// id-gate-driven systemPrompt. Until the gate flip in #154 the field
+// is informational; ComposeOutput exposes it so PR4's L2 tests can
+// A/B both paths.
 type BaseCrew struct {
-	id           string
-	name         string
-	role         string
-	model        string
-	verbosity    string
-	systemPrompt string
-	announcesAs  string
-	voiceModel   string
-	tools        []string
-	skills       []string
+	id            string
+	name          string
+	role          string
+	model         string
+	verbosity     string
+	systemPrompt  string
+	composeOutput string
+	announcesAs   string
+	voiceModel    string
+	tools         []string
+	skills        []string
 }
 
-func (c *BaseCrew) ID() string           { return c.id }
-func (c *BaseCrew) Name() string         { return c.name }
-func (c *BaseCrew) Role() string         { return c.role }
-func (c *BaseCrew) Model() string        { return c.model }
-func (c *BaseCrew) Verbosity() string    { return c.verbosity }
-func (c *BaseCrew) SystemPrompt() string { return c.systemPrompt }
-func (c *BaseCrew) AnnouncesAs() string  { return c.announcesAs }
-func (c *BaseCrew) VoiceModel() string   { return c.voiceModel }
+func (c *BaseCrew) ID() string            { return c.id }
+func (c *BaseCrew) Name() string          { return c.name }
+func (c *BaseCrew) Role() string          { return c.role }
+func (c *BaseCrew) Model() string         { return c.model }
+func (c *BaseCrew) Verbosity() string     { return c.verbosity }
+func (c *BaseCrew) SystemPrompt() string  { return c.systemPrompt }
+func (c *BaseCrew) ComposeOutput() string { return c.composeOutput }
+func (c *BaseCrew) AnnouncesAs() string   { return c.announcesAs }
+func (c *BaseCrew) VoiceModel() string    { return c.voiceModel }
 func (c *BaseCrew) Tools() []string {
 	if len(c.tools) == 0 {
 		return nil

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -2,6 +2,7 @@ package crew
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -44,10 +45,14 @@ type crewEntryYAML struct {
 	SystemPrompt string    `yaml:"system_prompt"`
 	Tools        []string  `yaml:"tools"`
 	// Skills is the optional list of skill names whose SKILL.md (and
-	// optional profile.md) get appended to the crew member's system
-	// prompt at registry-load time via the skills package's Compose
-	// function. Empty / omitted means the crew gets persona+verbosity
-	// only — current Maren/Crest/Bosun/Lookout behaviour.
+	// optional profile.md) drive the Compose-rendered prompt for this
+	// crew member at registry-load time via the skills package's
+	// Compose function. The result is stored on
+	// BaseCrew.composeOutput and reachable via Crew.ComposeOutput;
+	// SystemPrompt continues to return the id-gate output until the
+	// gate flip in #154. Empty / omitted means the crew gets
+	// persona+verbosity only — current Maren/Crest/Bosun/Lookout
+	// behaviour.
 	Skills []string `yaml:"skills"`
 }
 
@@ -264,26 +269,43 @@ type SkillChecker interface {
 }
 
 // ValidateSkills checks that every skill declared in crew.yaml resolves
-// against checker. Returns a sorted, comma-separated error listing all
-// missing skills, or nil when every entry resolves cleanly. Mirrors
-// ValidateTools.
+// against checker. Returns nil when every entry resolves cleanly, or
+// an aggregated error formatted as a newline-indented bullet list of
+// per-crew issues (mirroring ValidateTools). Issue messages distinguish
+// between three failure modes so operators can diagnose without
+// chasing the source error:
 //
-// LoadWithSource already fails fast on unresolvable skills via Compose's
-// wrapped ErrNotFound. ValidateSkills exists for pre-load checks and
-// for parity with ValidateTools — main.go can call both after Load to
-// surface inconsistencies independently of the load path.
+//   - skills.ErrNotFound       → "unknown skill" (skill name not in source)
+//   - skills.ErrInvalidSkillName → "invalid skill name" (regex mismatch)
+//   - any other error          → "validating skill: <error>" (I/O, etc.)
+//
+// LoadWithSource already fails fast on unresolvable skills via
+// Compose's wrapped ErrNotFound, so ValidateSkills exists primarily
+// for pre-load consistency checks (e.g. comparing a candidate dotfiles
+// ref against the currently-declared crew.yaml) and for parity with
+// ValidateTools — main.go can call both after Load to surface
+// inconsistencies independently of the load path.
 func (r *Registry) ValidateSkills(checker SkillChecker) error {
-	var missing []string
+	var issues []string
 	for id, c := range r.crew {
 		for _, name := range c.Skills() {
-			if _, err := checker.Skill(name); err != nil {
-				missing = append(missing, fmt.Sprintf("crew %s: unknown skill %q (not in skill source)", id, name))
+			_, err := checker.Skill(name)
+			if err == nil {
+				continue
+			}
+			switch {
+			case errors.Is(err, skills.ErrNotFound):
+				issues = append(issues, fmt.Sprintf("crew %s: unknown skill %q (not in skill source)", id, name))
+			case errors.Is(err, skills.ErrInvalidSkillName):
+				issues = append(issues, fmt.Sprintf("crew %s: invalid skill name %q (must match %s)", id, name, "[a-z0-9][a-z0-9-]*"))
+			default:
+				issues = append(issues, fmt.Sprintf("crew %s: validating skill %q: %v", id, name, err))
 			}
 		}
 	}
-	if len(missing) == 0 {
+	if len(issues) == 0 {
 		return nil
 	}
-	sort.Strings(missing)
-	return fmt.Errorf("skill validation failed:\n  %s", strings.Join(missing, "\n  "))
+	sort.Strings(issues)
+	return fmt.Errorf("skill validation failed:\n  %s", strings.Join(issues, "\n  "))
 }

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -91,10 +91,14 @@ func Load(path string) (*Registry, error) {
 // SystemPrompt(), new output through ComposeOutput(), both renderable
 // without changing crew.yaml.
 //
-// A declared skill that fails to resolve (Compose returns an error)
-// causes LoadWithSource to fail. Callers must supply a source that
-// covers every skill name declared in crew.yaml, or use ValidateSkills
-// up front to list missing skills before constructing the registry.
+// LoadWithSource fails fast on any skill that does not resolve via the
+// supplied source: Compose's wrapped ErrNotFound (or ErrUniversalRequired
+// for a missing universal) propagates out. To pre-flight a candidate
+// source against an already-loaded registry — e.g. comparing an
+// updated dotfiles ref against the currently-deployed crew.yaml before
+// rolling out — first load with a known-good source (typically the
+// default EmbeddedSource via Load), then call Registry.ValidateSkills
+// against the candidate.
 func LoadWithSource(path string, source skills.Source) (*Registry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -258,35 +262,70 @@ func (r *Registry) ValidateTools(checker ToolChecker) error {
 	return fmt.Errorf("tool validation failed:\n  %s", strings.Join(missing, "\n  "))
 }
 
-// SkillChecker is the narrow interface used by ValidateSkills. The
-// skills.Source interface satisfies it (Skill is one of its three
-// methods), so production callers pass the same source they used at
-// LoadWithSource time. A custom checker can also be supplied for
-// pre-load consistency checks (e.g. comparing a candidate dotfiles
-// ref against the currently-declared crew.yaml).
+// SkillChecker is the narrow interface used by ValidateSkills. It
+// covers exactly what ValidateSkills needs to verify Compose's
+// prerequisites at this caller layer: the universal addendum (required
+// when any crew has declared skills) and each declared skill's
+// SKILL.md. Profile is deliberately omitted since Compose treats
+// missing profiles as soft.
+//
+// skills.Source satisfies SkillChecker via duck typing, so production
+// callers pass the same source they used at LoadWithSource time. A
+// custom checker can also be supplied to compare a candidate source
+// against the loaded registry without re-running Load.
 type SkillChecker interface {
+	Universal() (skills.Doc, error)
 	Skill(name string) (skills.Doc, error)
 }
 
-// ValidateSkills checks that every skill declared in crew.yaml resolves
-// against checker. Returns nil when every entry resolves cleanly, or
-// an aggregated error formatted as a newline-indented bullet list of
+// ValidateSkills checks that the supplied checker resolves the full set
+// of inputs Compose would need at registry load time:
+//
+//  1. The universal addendum (_universal.md), required when any crew
+//     has at least one declared skill — Compose's ErrUniversalRequired
+//     fires otherwise.
+//  2. Each declared skill's SKILL.md, per crew.
+//
+// Returns nil when every prerequisite resolves cleanly, or an
+// aggregated error formatted as a newline-indented bullet list of
 // per-crew issues (mirroring ValidateTools). Issue messages distinguish
 // between three failure modes so operators can diagnose without
 // chasing the source error:
 //
-//   - skills.ErrNotFound       → "unknown skill" (skill name not in source)
+//   - skills.ErrNotFound         → "unknown skill" (or "universal addendum missing")
 //   - skills.ErrInvalidSkillName → "invalid skill name" (regex mismatch)
-//   - any other error          → "validating skill: <error>" (I/O, etc.)
+//   - any other error            → "validating skill: <err>" (I/O, etc.)
 //
-// LoadWithSource already fails fast on unresolvable skills via
-// Compose's wrapped ErrNotFound, so ValidateSkills exists primarily
-// for pre-load consistency checks (e.g. comparing a candidate dotfiles
-// ref against the currently-declared crew.yaml) and for parity with
-// ValidateTools — main.go can call both after Load to surface
-// inconsistencies independently of the load path.
+// LoadWithSource already fails fast on unresolvable skills via Compose's
+// wrapped ErrNotFound (or ErrUniversalRequired). ValidateSkills exists
+// primarily for pre-deployment consistency checks against a *candidate*
+// source — load with a known-good source first, then call ValidateSkills
+// against the candidate to list every issue without committing to a
+// reload.
 func (r *Registry) ValidateSkills(checker SkillChecker) error {
 	var issues []string
+
+	// Universal is a prerequisite only when at least one crew has
+	// declared skills (matches Compose's behaviour: empty skills slice
+	// returns the persona unchanged without consulting Universal).
+	anySkills := false
+	for _, c := range r.crew {
+		if len(c.Skills()) > 0 {
+			anySkills = true
+			break
+		}
+	}
+	if anySkills {
+		if _, err := checker.Universal(); err != nil {
+			switch {
+			case errors.Is(err, skills.ErrNotFound):
+				issues = append(issues, `universal addendum missing ("_universal.md" not in skill source)`)
+			default:
+				issues = append(issues, fmt.Sprintf("validating universal addendum: %v", err))
+			}
+		}
+	}
+
 	for id, c := range r.crew {
 		for _, name := range c.Skills() {
 			_, err := checker.Skill(name)

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -133,7 +133,11 @@ func LoadWithSource(path string, source skills.Source) (*Registry, error) {
 		if !ok {
 			return nil, fmt.Errorf("crew %s: unknown verbosity %q", id, entry.Verbosity)
 		}
-		prompt := strings.ReplaceAll(entry.SystemPrompt, "{verbosity}", verbDesc)
+		// Render the persona once with {verbosity} substituted, then
+		// derive both prompt paths from it. The id-gate mutates only
+		// `prompt`; Compose receives the unmutated persona.
+		persona := strings.ReplaceAll(entry.SystemPrompt, "{verbosity}", verbDesc)
+		prompt := persona
 		if id == "chips" {
 			// TrimRight bounds the separator on the prompt side: YAML `|`
 			// literal block scalars produce a trailing newline today, but
@@ -149,7 +153,6 @@ func LoadWithSource(path string, source skills.Source) (*Registry, error) {
 		// the gate flip.
 		var composeOutput string
 		if len(entry.Skills) > 0 {
-			persona := strings.ReplaceAll(entry.SystemPrompt, "{verbosity}", verbDesc)
 			composed, err := skills.Compose(persona, entry.Skills, source)
 			if err != nil {
 				return nil, fmt.Errorf("crew %s: %w", id, err)
@@ -304,30 +307,17 @@ type SkillChecker interface {
 // reload.
 func (r *Registry) ValidateSkills(checker SkillChecker) error {
 	var issues []string
-
-	// Universal is a prerequisite only when at least one crew has
-	// declared skills (matches Compose's behaviour: empty skills slice
-	// returns the persona unchanged without consulting Universal).
 	anySkills := false
-	for _, c := range r.crew {
-		if len(c.Skills()) > 0 {
-			anySkills = true
-			break
-		}
-	}
-	if anySkills {
-		if _, err := checker.Universal(); err != nil {
-			switch {
-			case errors.Is(err, skills.ErrNotFound):
-				issues = append(issues, `universal addendum missing ("_universal.md" not in skill source)`)
-			default:
-				issues = append(issues, fmt.Sprintf("validating universal addendum: %v", err))
-			}
-		}
-	}
 
+	// Per-crew pass: compute anySkills inline and walk each declared
+	// skill exactly once. Caching c.Skills() per crew avoids the
+	// double defensive-copy that Skills() incurs.
 	for id, c := range r.crew {
-		for _, name := range c.Skills() {
+		skillNames := c.Skills()
+		if len(skillNames) > 0 {
+			anySkills = true
+		}
+		for _, name := range skillNames {
 			_, err := checker.Skill(name)
 			if err == nil {
 				continue
@@ -342,6 +332,23 @@ func (r *Registry) ValidateSkills(checker SkillChecker) error {
 			}
 		}
 	}
+
+	// Universal is a prerequisite only when at least one crew has
+	// declared skills (matches Compose's behaviour: empty skills slice
+	// returns the persona unchanged without consulting Universal).
+	// Run after the per-skill pass — sort.Strings below normalises
+	// output order regardless of insertion order.
+	if anySkills {
+		if _, err := checker.Universal(); err != nil {
+			switch {
+			case errors.Is(err, skills.ErrNotFound):
+				issues = append(issues, `universal addendum missing ("_universal.md" not in skill source)`)
+			default:
+				issues = append(issues, fmt.Sprintf("validating universal addendum: %v", err))
+			}
+		}
+	}
+
 	if len(issues) == 0 {
 		return nil
 	}

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"klazomenai/bridge/internal/crew/skills"
 )
 
 // chipsGitHubSkill is the curated github skill body, vendored from the operator's
@@ -60,8 +62,35 @@ type Registry struct {
 	crew        map[string]Crew
 }
 
-// Load parses the crew YAML at path and returns a Registry.
+// Load parses the crew YAML at path and returns a Registry. Skills
+// declared on crew entries (via the `skills: []` field) are composed
+// against an EmbeddedSource by default — production callers wanting
+// to layer a filesystem override on top should call LoadWithSource
+// with a FallbackSource.
 func Load(path string) (*Registry, error) {
+	return LoadWithSource(path, skills.EmbeddedSource{})
+}
+
+// LoadWithSource is Load with a caller-provided skills.Source. Used by
+// tests (injecting a MapSource for hermetic Compose-output assertions)
+// and by future callers (e.g. main.go) that want to layer a filesystem
+// override over the embedded fallback.
+//
+// For each crew entry with a non-empty `skills:` list, this function
+// invokes skills.Compose against the supplied source and stores the
+// rendered prompt on BaseCrew.composeOutput, reachable via
+// BaseCrew.ComposeOutput. The legacy `if id == "chips"` gate remains
+// the source of truth for SystemPrompt() in this sub-PR — the gate
+// flip happens in #154 (PR4). This dual-path arrangement gives PR4's
+// L2 enforcement tests an A/B affordance: legacy output through
+// SystemPrompt(), new output through ComposeOutput(), both renderable
+// without changing crew.yaml.
+//
+// A declared skill that fails to resolve (Compose returns an error)
+// causes LoadWithSource to fail. Callers must supply a source that
+// covers every skill name declared in crew.yaml, or use ValidateSkills
+// up front to list missing skills before constructing the registry.
+func LoadWithSource(path string, source skills.Source) (*Registry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading crew registry %s: %w", path, err)
@@ -103,17 +132,34 @@ func Load(path string) (*Registry, error) {
 			// keeps the boundary stable regardless of YAML chomp style.
 			prompt = strings.TrimRight(prompt, "\n") + "\n\n" + chipsGitHubSkill
 		}
+
+		// Dual-path: render the Compose-based prompt for any crew with
+		// declared skills. The legacy id-gate above still wins for
+		// SystemPrompt() in this PR; the new prompt is reachable via
+		// ComposeOutput() so PR4's L2 tests can A/B both paths before
+		// the gate flip.
+		var composeOutput string
+		if len(entry.Skills) > 0 {
+			persona := strings.ReplaceAll(entry.SystemPrompt, "{verbosity}", verbDesc)
+			composed, err := skills.Compose(persona, entry.Skills, source)
+			if err != nil {
+				return nil, fmt.Errorf("crew %s: %w", id, err)
+			}
+			composeOutput = composed
+		}
+
 		registry.crew[id] = &BaseCrew{
-			id:           id,
-			name:         entry.Name,
-			role:         entry.Role,
-			model:        entry.Model,
-			verbosity:    entry.Verbosity,
-			systemPrompt: prompt,
-			announcesAs:  entry.Voice.AnnouncesAs,
-			voiceModel:   entry.Voice.Model,
-			tools:        entry.Tools,
-			skills:       entry.Skills,
+			id:            id,
+			name:          entry.Name,
+			role:          entry.Role,
+			model:         entry.Model,
+			verbosity:     entry.Verbosity,
+			systemPrompt:  prompt,
+			composeOutput: composeOutput,
+			announcesAs:   entry.Voice.AnnouncesAs,
+			voiceModel:    entry.Voice.Model,
+			tools:         entry.Tools,
+			skills:        entry.Skills,
 		}
 	}
 
@@ -205,4 +251,39 @@ func (r *Registry) ValidateTools(checker ToolChecker) error {
 	}
 	sort.Strings(missing)
 	return fmt.Errorf("tool validation failed:\n  %s", strings.Join(missing, "\n  "))
+}
+
+// SkillChecker is the narrow interface used by ValidateSkills. The
+// skills.Source interface satisfies it (Skill is one of its three
+// methods), so production callers pass the same source they used at
+// LoadWithSource time. A custom checker can also be supplied for
+// pre-load consistency checks (e.g. comparing a candidate dotfiles
+// ref against the currently-declared crew.yaml).
+type SkillChecker interface {
+	Skill(name string) (skills.Doc, error)
+}
+
+// ValidateSkills checks that every skill declared in crew.yaml resolves
+// against checker. Returns a sorted, comma-separated error listing all
+// missing skills, or nil when every entry resolves cleanly. Mirrors
+// ValidateTools.
+//
+// LoadWithSource already fails fast on unresolvable skills via Compose's
+// wrapped ErrNotFound. ValidateSkills exists for pre-load checks and
+// for parity with ValidateTools — main.go can call both after Load to
+// surface inconsistencies independently of the load path.
+func (r *Registry) ValidateSkills(checker SkillChecker) error {
+	var missing []string
+	for id, c := range r.crew {
+		for _, name := range c.Skills() {
+			if _, err := checker.Skill(name); err != nil {
+				missing = append(missing, fmt.Sprintf("crew %s: unknown skill %q (not in skill source)", id, name))
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return fmt.Errorf("skill validation failed:\n  %s", strings.Join(missing, "\n  "))
 }

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -336,7 +336,7 @@ func (r *Registry) ValidateSkills(checker SkillChecker) error {
 			case errors.Is(err, skills.ErrNotFound):
 				issues = append(issues, fmt.Sprintf("crew %s: unknown skill %q (not in skill source)", id, name))
 			case errors.Is(err, skills.ErrInvalidSkillName):
-				issues = append(issues, fmt.Sprintf("crew %s: invalid skill name %q (must match %s)", id, name, "[a-z0-9][a-z0-9-]*"))
+				issues = append(issues, fmt.Sprintf("crew %s: invalid skill name %q (must match %s)", id, name, skills.SkillNameConstraint))
 			default:
 				issues = append(issues, fmt.Sprintf("crew %s: validating skill %q: %v", id, name, err))
 			}

--- a/internal/crew/registry.go
+++ b/internal/crew/registry.go
@@ -41,6 +41,12 @@ type crewEntryYAML struct {
 	Voice        voiceYAML `yaml:"voice"`
 	SystemPrompt string    `yaml:"system_prompt"`
 	Tools        []string  `yaml:"tools"`
+	// Skills is the optional list of skill names whose SKILL.md (and
+	// optional profile.md) get appended to the crew member's system
+	// prompt at registry-load time via the skills package's Compose
+	// function. Empty / omitted means the crew gets persona+verbosity
+	// only — current Maren/Crest/Bosun/Lookout behaviour.
+	Skills []string `yaml:"skills"`
 }
 
 type voiceYAML struct {
@@ -107,6 +113,7 @@ func Load(path string) (*Registry, error) {
 			announcesAs:  entry.Voice.AnnouncesAs,
 			voiceModel:   entry.Voice.Model,
 			tools:        entry.Tools,
+			skills:       entry.Skills,
 		}
 	}
 
@@ -138,6 +145,16 @@ func validateEntry(id string, e crewEntryYAML) error {
 	}
 	if e.Voice.AnnouncesAs == "" {
 		return fmt.Errorf("crew %s: voice.announces_as is required", id)
+	}
+	seen := make(map[string]bool, len(e.Skills))
+	for _, name := range e.Skills {
+		if name == "" {
+			return fmt.Errorf("crew %s: skill name must not be empty", id)
+		}
+		if seen[name] {
+			return fmt.Errorf("crew %s: duplicate skill %q", id, name)
+		}
+		seen[name] = true
 	}
 	return nil
 }

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -1042,7 +1042,9 @@ func TestValidateSkillsMissing(t *testing.T) {
 	// Build the registry via LoadWithSource with a source that DOES
 	// have github (so Load succeeds), then ValidateSkills against an
 	// empty source — proving the validator surfaces missing skills
-	// regardless of which source was used at Load time.
+	// regardless of which source was used at Load time. An empty
+	// source also has no universal addendum, so we expect both the
+	// per-skill issue AND the universal-missing issue.
 	path := writeRegistry(t, yamlWithChipsSkill)
 	loadSrc := mapSource{
 		"_universal.md":     "UNIV",
@@ -1063,15 +1065,127 @@ func TestValidateSkillsMissing(t *testing.T) {
 	if !strings.Contains(err.Error(), "chips") {
 		t.Errorf("expected error to mention crew id chips, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "universal addendum missing") {
+		t.Errorf("expected error to mention missing universal addendum, got: %v", err)
+	}
 }
 
-// errorSource is a test-only Source whose Skill always returns the
-// configured error. Used by ValidateSkills tests to exercise the
-// per-error-class branches (ErrNotFound, ErrInvalidSkillName, other).
-type errorSource struct{ skillErr error }
+func TestValidateSkillsRequiresUniversalWhenSkillsDeclared(t *testing.T) {
+	// Source has the github SKILL.md but no _universal.md. With at
+	// least one crew declaring skills, ValidateSkills must surface a
+	// universal-missing issue even though every per-skill name resolves.
+	// (Compose's ErrUniversalRequired is the runtime equivalent of
+	// this; ValidateSkills lets operators catch it before runtime.)
+	path := writeRegistry(t, yamlWithChipsSkill)
+	loadSrc := mapSource{
+		"_universal.md":     "UNIV",
+		"github/SKILL.md":   "SKILL",
+		"github/profile.md": "PROFILE",
+	}
+	r, err := crew.LoadWithSource(path, loadSrc)
+	if err != nil {
+		t.Fatalf("LoadWithSource: %v", err)
+	}
+	candidate := mapSource{
+		// no _universal.md — the candidate would silently pass a
+		// skills-only validator, which is the bug we're guarding.
+		"github/SKILL.md":   "SKILL",
+		"github/profile.md": "PROFILE",
+	}
+	err = r.ValidateSkills(candidate)
+	if err == nil {
+		t.Fatal("expected validation error for missing universal")
+	}
+	if !strings.Contains(err.Error(), "universal addendum missing") {
+		t.Errorf("expected universal-missing message, got: %v", err)
+	}
+	// The per-skill check must NOT fire (github resolves) — pin that
+	// the per-skill and universal paths are independent.
+	if strings.Contains(err.Error(), "unknown skill") {
+		t.Errorf("github resolves; should not report unknown skill: %v", err)
+	}
+}
+
+func TestValidateSkillsSkipsUniversalCheckWhenNoSkillsDeclared(t *testing.T) {
+	// validYAML has no skills declared on any crew, so universal is
+	// not a prerequisite. A checker with no Universal must NOT trigger
+	// a universal-missing issue.
+	path := writeRegistry(t, validYAML)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := r.ValidateSkills(mapSource{}); err != nil {
+		t.Errorf("expected no error when no skills declared, got: %v", err)
+	}
+}
+
+func TestValidateSkillsUniversalErrorClasses(t *testing.T) {
+	// Mirror the per-skill class test for the universal path. Skill
+	// returns nil so per-skill issues don't pollute; only the
+	// universal branch triggers.
+	path := writeRegistry(t, yamlWithChipsSkill)
+	loadSrc := mapSource{
+		"_universal.md":     "UNIV",
+		"github/SKILL.md":   "SKILL",
+		"github/profile.md": "PROFILE",
+	}
+	r, err := crew.LoadWithSource(path, loadSrc)
+	if err != nil {
+		t.Fatalf("LoadWithSource: %v", err)
+	}
+
+	cases := []struct {
+		name         string
+		universalErr error
+		wantSubstr   string
+	}{
+		{
+			name:         "ErrNotFound → universal addendum missing",
+			universalErr: skills.ErrNotFound,
+			wantSubstr:   "universal addendum missing",
+		},
+		{
+			name:         "other error → validating universal addendum: <err>",
+			universalErr: errors.New("permission denied"),
+			wantSubstr:   "validating universal addendum",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// skillErr=nil so per-skill branch never fires; only the
+			// universal branch can surface an issue.
+			src := errorSource{universalErr: tc.universalErr, skillErr: nil}
+			// With skillErr=nil, errorSource.Skill returns (zero Doc, nil) —
+			// ValidateSkills treats that as "skill resolved".
+			err := r.ValidateSkills(src)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("expected error to contain %q, got: %v", tc.wantSubstr, err)
+			}
+		})
+	}
+}
+
+// errorSource is a test-only Source with configurable per-method
+// errors. Used by ValidateSkills tests to exercise the
+// per-error-class branches (ErrNotFound, ErrInvalidSkillName, other)
+// for both Universal and Skill independently. Universal succeeds by
+// default so per-skill tests aren't polluted with a spurious
+// universal-missing issue; tests that want to exercise the universal
+// check set universalErr explicitly.
+type errorSource struct {
+	skillErr     error
+	universalErr error
+}
 
 func (e errorSource) Universal() (skills.Doc, error) {
-	return skills.Doc{}, skills.ErrNotFound
+	if e.universalErr != nil {
+		return skills.Doc{}, e.universalErr
+	}
+	return skills.Doc{Path: "_universal.md", Content: "UNIV"}, nil
 }
 
 func (e errorSource) Skill(_ string) (skills.Doc, error) {

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -1,12 +1,14 @@
 package crew_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"klazomenai/bridge/internal/crew"
+	"klazomenai/bridge/internal/crew/skills"
 )
 
 const validYAML = `
@@ -279,7 +281,7 @@ crew:
 `,
 		},
 		{
-			name: "uppercase crew ID",
+			name: "uppercase default_crew",
 			yaml: `
 default_crew: Maren
 crew:
@@ -293,6 +295,34 @@ crew:
       announces_as: "Maren:"
     system_prompt: "prompt"
 `,
+		},
+		{
+			// default_crew lowercase passes the early check at the top of
+			// LoadWithSource; the uppercase MAP KEY then hits the loop's
+			// id != strings.ToLower(id) check inside the for-each. This
+			// is a different code path than the "uppercase default_crew"
+			// case above (which short-circuits on the prior check).
+			name: "uppercase crew map key",
+			yaml: `
+default_crew: maren
+crew:
+  Maren:
+    name: "Maren"
+    role: "Shipwright"
+    model: "claude-sonnet-4-6"
+    verbosity: dispatch
+    voice:
+      model: "x.onnx"
+      announces_as: "Maren:"
+    system_prompt: "prompt"
+`,
+		},
+		{
+			// Hits the yaml.Unmarshal error path (vs. the post-parse
+			// validation paths above). Unclosed flow sequence is a clean
+			// YAML syntax error that the parser cannot recover from.
+			name: "malformed yaml syntax",
+			yaml: "default_crew: [unclosed",
 		},
 	}
 	for _, tc := range cases {
@@ -825,5 +855,243 @@ crew:
 	}
 	if !strings.Contains(err.Error(), "must not be empty") {
 		t.Errorf("expected must-not-be-empty in error, got: %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Dual-path Source/Compose wiring (#153)
+//
+// LoadWithSource invokes skills.Compose for any crew with a non-empty
+// `skills:` list and stores the rendered prompt on BaseCrew alongside
+// the (still-winning) id-gate output. The legacy SystemPrompt() keeps
+// returning the id-gate value; ComposeOutput() exposes the new value
+// for PR4's L2 enforcement tests to A/B both paths.
+// ----------------------------------------------------------------------
+
+const yamlWithChipsSkill = `
+default_crew: chips
+crew:
+  chips:
+    name: "Chips"
+    role: "The Carpenter"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    skills: [github]
+    voice:
+      model: TBD
+      announces_as: "Chips:"
+    system_prompt: "You are Chips. Respond in {verbosity}"
+`
+
+func TestComposeOutputContainsUniversalSentinels(t *testing.T) {
+	path := writeRegistry(t, yamlWithChipsSkill)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	out := r.Get("chips").ComposeOutput()
+	for _, sentinel := range []string{
+		"Operator Universal Rules",     // boundary marker
+		"Github Workflow Rules",        // boundary marker (titlecase)
+		"Github Profile Addendum",      // boundary marker (titlecase)
+		"Operator Intent Required",     // universal addendum content
+		"Conventional commits format",  // SKILL.md content
+	} {
+		if !strings.Contains(out, sentinel) {
+			t.Errorf("ComposeOutput missing sentinel %q\nfull output:\n%s", sentinel, out)
+		}
+	}
+}
+
+func TestComposeOutputBeginsWithPersona(t *testing.T) {
+	path := writeRegistry(t, yamlWithChipsSkill)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	out := r.Get("chips").ComposeOutput()
+	const wantPrefix = "You are Chips. Respond in Answer in a full paragraph"
+	if !strings.HasPrefix(out, wantPrefix) {
+		t.Errorf("ComposeOutput must begin with rendered persona, got:\n%s", out)
+	}
+}
+
+func TestNonSkillsCrewHasEmptyComposeOutput(t *testing.T) {
+	// validYAML (top of file) has no skills declared on any crew.
+	path := writeRegistry(t, validYAML)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, id := range []string{"maren", "crest", "bosun", "lookout", "chips"} {
+		if got := r.Get(id).ComposeOutput(); got != "" {
+			t.Errorf("crew %s: expected empty ComposeOutput, got %d bytes", id, len(got))
+		}
+	}
+}
+
+func TestSystemPromptUnchangedByComposePath(t *testing.T) {
+	// PR3 contract: id-gate still wins for SystemPrompt(); ComposeOutput
+	// is the new dual-path. The legacy assertion in
+	// TestChipsSystemPromptContainsGitHubSkill uses sentinel
+	// "Copilot Review Workflow" from the vendored skills/github.md
+	// (id-gate path), NOT from the embedded fixtures (Compose path).
+	// Until #154 flips the gate, both paths render independently.
+	path := writeRegistry(t, yamlWithChipsSkill)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	prompt := r.Get("chips").SystemPrompt()
+	if !strings.Contains(prompt, "Copilot Review Workflow") {
+		t.Error("SystemPrompt missing Copilot Review Workflow sentinel — id-gate may have been removed prematurely")
+	}
+}
+
+// ----------------------------------------------------------------------
+// LoadWithSource — test injection via mapSource
+// ----------------------------------------------------------------------
+
+// mapSource is a test-only Source backed by an in-memory map keyed by
+// canonical relative path (slash-separated, matching Doc.Path contract).
+// Lets LoadWithSource tests inject precise content without depending on
+// the embedded fixtures.
+type mapSource map[string]string
+
+func (m mapSource) Universal() (skills.Doc, error) {
+	if c, ok := m["_universal.md"]; ok {
+		return skills.Doc{Path: "_universal.md", Content: c}, nil
+	}
+	return skills.Doc{}, skills.ErrNotFound
+}
+
+func (m mapSource) Skill(name string) (skills.Doc, error) {
+	key := name + "/SKILL.md"
+	if c, ok := m[key]; ok {
+		return skills.Doc{Path: key, Content: c}, nil
+	}
+	return skills.Doc{}, skills.ErrNotFound
+}
+
+func (m mapSource) Profile(name string) (skills.Doc, error) {
+	key := name + "/profile.md"
+	if c, ok := m[key]; ok {
+		return skills.Doc{Path: key, Content: c}, nil
+	}
+	return skills.Doc{}, skills.ErrNotFound
+}
+
+func TestLoadWithSourceFailsOnUnknownSkill(t *testing.T) {
+	// Empty source → Compose wraps ErrNotFound for the missing skill →
+	// LoadWithSource propagates with the crew id in the error.
+	path := writeRegistry(t, yamlWithChipsSkill)
+	_, err := crew.LoadWithSource(path, mapSource{})
+	if err == nil {
+		t.Fatal("expected error for unknown skill")
+	}
+	if !errors.Is(err, skills.ErrNotFound) {
+		t.Errorf("expected wrapped ErrNotFound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "chips") {
+		t.Errorf("expected error to mention crew id chips, got %v", err)
+	}
+}
+
+func TestLoadWithSourceUsesInjectedSource(t *testing.T) {
+	// Hermetic: injected source provides distinctive sentinels that
+	// EmbeddedSource doesn't. ComposeOutput must contain them, proving
+	// LoadWithSource routed through the injected source.
+	path := writeRegistry(t, yamlWithChipsSkill)
+	src := mapSource{
+		"_universal.md":     "INJECTED-UNIV-SENTINEL",
+		"github/SKILL.md":   "INJECTED-SKILL-SENTINEL",
+		"github/profile.md": "INJECTED-PROFILE-SENTINEL",
+	}
+	r, err := crew.LoadWithSource(path, src)
+	if err != nil {
+		t.Fatalf("LoadWithSource: %v", err)
+	}
+	out := r.Get("chips").ComposeOutput()
+	for _, want := range []string{
+		"INJECTED-UNIV-SENTINEL",
+		"INJECTED-SKILL-SENTINEL",
+		"INJECTED-PROFILE-SENTINEL",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ComposeOutput missing injected sentinel %q", want)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// ValidateSkills (mirrors ValidateTools)
+// ----------------------------------------------------------------------
+
+func TestValidateSkillsAllPresent(t *testing.T) {
+	path := writeRegistry(t, yamlWithChipsSkill)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := r.ValidateSkills(skills.EmbeddedSource{}); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateSkillsMissing(t *testing.T) {
+	// Build the registry via LoadWithSource with a source that DOES
+	// have github (so Load succeeds), then ValidateSkills against an
+	// empty source — proving the validator surfaces missing skills
+	// regardless of which source was used at Load time.
+	path := writeRegistry(t, yamlWithChipsSkill)
+	loadSrc := mapSource{
+		"_universal.md":     "UNIV",
+		"github/SKILL.md":   "SKILL",
+		"github/profile.md": "PROFILE",
+	}
+	r, err := crew.LoadWithSource(path, loadSrc)
+	if err != nil {
+		t.Fatalf("LoadWithSource: %v", err)
+	}
+	err = r.ValidateSkills(mapSource{})
+	if err == nil {
+		t.Fatal("expected validation error for missing skill")
+	}
+	if !strings.Contains(err.Error(), "github") {
+		t.Errorf("expected error to mention skill name github, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "chips") {
+		t.Errorf("expected error to mention crew id chips, got: %v", err)
+	}
+}
+
+func TestValidateSkillsNoSkillsDeclared(t *testing.T) {
+	// Empty checker — no skills resolvable, but no skills declared
+	// either. Mirrors TestValidateToolsNoToolsDeclared.
+	path := writeRegistry(t, validYAML)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := r.ValidateSkills(mapSource{}); err != nil {
+		t.Errorf("expected no error when no skills declared, got: %v", err)
+	}
+}
+
+func TestEmbeddedSourceContainsAllSkillsDeclaredInRealCrewYAML(t *testing.T) {
+	// Pin the contract that every skill declared in the real
+	// config/crew.yaml resolves via the EmbeddedSource — equivalent
+	// in spirit to validating production tool registry against the
+	// production tool list.
+	configPath := "../../config/crew.yaml"
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("real config/crew.yaml not present (running outside repo?): %v", err)
+	}
+	r, err := crew.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load real crew.yaml: %v", err)
+	}
+	if err := r.ValidateSkills(skills.EmbeddedSource{}); err != nil {
+		t.Errorf("ValidateSkills against EmbeddedSource: %v", err)
 	}
 }

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -1065,6 +1065,77 @@ func TestValidateSkillsMissing(t *testing.T) {
 	}
 }
 
+// errorSource is a test-only Source whose Skill always returns the
+// configured error. Used by ValidateSkills tests to exercise the
+// per-error-class branches (ErrNotFound, ErrInvalidSkillName, other).
+type errorSource struct{ skillErr error }
+
+func (e errorSource) Universal() (skills.Doc, error) {
+	return skills.Doc{}, skills.ErrNotFound
+}
+
+func (e errorSource) Skill(_ string) (skills.Doc, error) {
+	return skills.Doc{}, e.skillErr
+}
+
+func (e errorSource) Profile(_ string) (skills.Doc, error) {
+	return skills.Doc{}, skills.ErrNotFound
+}
+
+func TestValidateSkillsDistinguishesErrorClasses(t *testing.T) {
+	// Build registry with chips:[github] declared; vary the checker's
+	// returned error to exercise each branch of the switch.
+	path := writeRegistry(t, yamlWithChipsSkill)
+	loadSrc := mapSource{
+		"_universal.md":     "UNIV",
+		"github/SKILL.md":   "SKILL",
+		"github/profile.md": "PROFILE",
+	}
+	r, err := crew.LoadWithSource(path, loadSrc)
+	if err != nil {
+		t.Fatalf("LoadWithSource: %v", err)
+	}
+
+	cases := []struct {
+		name        string
+		checkerErr  error
+		wantSubstr  string
+		wantNoSubstr string // optional: must NOT appear
+	}{
+		{
+			name:       "ErrNotFound → unknown skill",
+			checkerErr: skills.ErrNotFound,
+			wantSubstr: "unknown skill",
+		},
+		{
+			name:       "ErrInvalidSkillName → invalid skill name",
+			checkerErr: skills.ErrInvalidSkillName,
+			wantSubstr: "invalid skill name",
+			// must NOT misreport as "unknown" — that's the bug fix.
+			wantNoSubstr: "unknown skill",
+		},
+		{
+			name:       "other error → validating skill: <err>",
+			checkerErr: errors.New("permission denied"),
+			wantSubstr: "validating skill",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := r.ValidateSkills(errorSource{skillErr: tc.checkerErr})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("expected error to contain %q, got: %v", tc.wantSubstr, err)
+			}
+			if tc.wantNoSubstr != "" && strings.Contains(err.Error(), tc.wantNoSubstr) {
+				t.Errorf("error should NOT contain %q (misreport bug); got: %v", tc.wantNoSubstr, err)
+			}
+		})
+	}
+}
+
 func TestValidateSkillsNoSkillsDeclared(t *testing.T) {
 	// Empty checker — no skills resolvable, but no skills declared
 	// either. Mirrors TestValidateToolsNoToolsDeclared.

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -739,3 +739,91 @@ func TestNonChipsCrewLackGitHubSkill(t *testing.T) {
 		}
 	}
 }
+
+const yamlWithSkills = `
+default_crew: chips
+crew:
+  chips:
+    name: "Chips"
+    role: "The Carpenter"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    skills: [github]
+    voice:
+      model: TBD
+      announces_as: "Chips:"
+    system_prompt: "You are Chips. Respond in {verbosity}"
+`
+
+func TestSkillsParsedFromYAML(t *testing.T) {
+	path := writeRegistry(t, yamlWithSkills)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	chips := r.Get("chips")
+	if got := chips.Skills(); len(got) != 1 || got[0] != "github" {
+		t.Errorf("expected [github], got %v", got)
+	}
+}
+
+func TestSkillsEmptyWhenOmitted(t *testing.T) {
+	path := writeRegistry(t, validYAML)
+	r, err := crew.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := r.Get("maren").Skills(); got != nil {
+		t.Errorf("expected nil skills for maren, got %v", got)
+	}
+}
+
+func TestSkillsRejectsDuplicates(t *testing.T) {
+	const dupYAML = `
+default_crew: chips
+crew:
+  chips:
+    name: "Chips"
+    role: "The Carpenter"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    skills: [github, github]
+    voice:
+      model: TBD
+      announces_as: "Chips:"
+    system_prompt: "You are Chips. Respond in {verbosity}"
+`
+	path := writeRegistry(t, dupYAML)
+	_, err := crew.Load(path)
+	if err == nil {
+		t.Fatal("expected duplicate-skill error")
+	}
+	if !strings.Contains(err.Error(), "duplicate skill") {
+		t.Errorf("expected duplicate-skill in error, got: %v", err)
+	}
+}
+
+func TestSkillsRejectsEmptyEntry(t *testing.T) {
+	const emptyYAML = `
+default_crew: chips
+crew:
+  chips:
+    name: "Chips"
+    role: "The Carpenter"
+    model: "claude-sonnet-4-6"
+    verbosity: log-entry
+    skills: [""]
+    voice:
+      model: TBD
+      announces_as: "Chips:"
+    system_prompt: "You are Chips. Respond in {verbosity}"
+`
+	path := writeRegistry(t, emptyYAML)
+	_, err := crew.Load(path)
+	if err == nil {
+		t.Fatal("expected empty-skill-name error")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("expected must-not-be-empty in error, got: %v", err)
+	}
+}

--- a/internal/crew/skills/loader.go
+++ b/internal/crew/skills/loader.go
@@ -66,9 +66,18 @@ func isNilSource(s Source) bool {
 // `crew.yaml` is the only producer of skill names today.
 var ErrInvalidSkillName = errors.New("skills: invalid skill name")
 
+// SkillNameConstraint is the human-readable form of the skill-name
+// constraint, exported so downstream error messages (e.g. in
+// crew.ValidateSkills) reference a single authoritative source rather
+// than copy-pasting the literal pattern. The runtime regex below is
+// built from this constant so the two cannot drift.
+const SkillNameConstraint = "[a-z0-9][a-z0-9-]*"
+
 // skillNamePattern matches the dotfiles `claude/skills/<name>/` naming
-// convention: lowercase alphanumeric with optional dashes.
-var skillNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+// convention: lowercase alphanumeric with optional dashes. Built from
+// SkillNameConstraint so the human-readable form and the regex stay
+// in lockstep.
+var skillNamePattern = regexp.MustCompile("^" + SkillNameConstraint + "$")
 
 // validateSkillName rejects names that would escape <Root>/ or break
 // the canonical relative path structure used by Doc.Path. Applied at


### PR DESCRIPTION
## Summary

Third sub-PR of [#148](https://github.com/Klazomenai/bridge/issues/148) (Source/Compose skill loader epic). Wires the `skills: []` field added in PR2 into the `skills.Compose` machinery added in PR1, alongside (not replacing) the legacy `if id == "chips"` gate. The gate flip is PR4 (#154) — keeping the load-bearing diff small and isolated.

## What's in this PR

### Schema (cherry-picked)

- `crewEntryYAML.Skills []string` field with `yaml:"skills"` tag (cherry-pick of `22c273b`)
- `Crew` interface gains `Skills() []string` accessor (defensive copy)
- `BaseCrew.skills` field with copy-semantics accessor
- `validateEntry` rejects empty entries and within-crew duplicates

### Source plumbing (new)

- **`crew.LoadWithSource(path string, source skills.Source) (*Registry, error)`** — test-injectable constructor. `crew.Load(path)` is now a thin wrapper that delegates with a default `skills.EmbeddedSource{}`. The `FallbackSource{FilesystemSource, EmbeddedSource}` layering arrives in PR5 when the image-mount infrastructure lands.
- **`BaseCrew.composeOutput` field + `Crew.ComposeOutput() string` accessor** — for each crew with a non-empty `skills:` list, `LoadWithSource` invokes `skills.Compose(persona, skills, source)` and stores the rendered prompt here. Empty for crew without declared skills. Until the gate flip in #154, `SystemPrompt()` still returns the id-gate-driven value; `ComposeOutput()` exposes the new path so PR4's L2 enforcement tests can A/B both.
- **`SkillChecker` interface + `Registry.ValidateSkills(checker)` method** — mirrors `ValidateTools`. Iterates declared skills across the registry; reports any that don't resolve. `skills.Source` satisfies `SkillChecker`.

### config/crew.yaml

- chips entry gains `skills: [github]`. Maren/Crest/Bosun/Lookout remain skills-less (preserves their persona-only prompts).

### Tests added (10 new tests)

| Test | Purpose |
|------|---------|
| `TestComposeOutputContainsUniversalSentinels` | Sentinel checks: universal/SKILL/profile boundaries, content from each |
| `TestComposeOutputBeginsWithPersona` | Persona prefix with `{verbosity}` substituted |
| `TestNonSkillsCrewHasEmptyComposeOutput` | All read-only crew get empty `ComposeOutput()` |
| `TestSystemPromptUnchangedByComposePath` | id-gate still wins for `SystemPrompt()` |
| `TestLoadWithSourceFailsOnUnknownSkill` | Empty source → wrapped `ErrNotFound` with crew id |
| `TestLoadWithSourceUsesInjectedSource` | Hermetic mapSource with `INJECTED-*` sentinels routes correctly |
| `TestValidateSkillsAllPresent` | Mirror of `TestValidateToolsAllPresent` |
| `TestValidateSkillsMissing` | Mirror of `TestValidateToolsMissing` |
| `TestValidateSkillsNoSkillsDeclared` | No skills, empty checker → no error |
| `TestEmbeddedSourceContainsAllSkillsDeclaredInRealCrewYAML` | Pins production-config consistency |

Plus two new subcases in `TestLoadMissingRequiredFieldErrors`: `"uppercase crew map key"` (hits the inner-loop lowercase check, distinct path from `"uppercase default_crew"` which short-circuits earlier) and `"malformed yaml syntax"` (hits the `yaml.Unmarshal` error path).

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./...` clean
- [x] `CGO_ENABLED=0 go test -tags goolm -count=1 ./internal/...` — all 14 packages green
- [x] **Coverage on `internal/crew`: 100.0%** (every symbol at 100%, including the previously-uncovered yaml-parse and uppercase-crew-key branches inherited from pre-`Load`)
- [x] Existing legacy assertions still pass: `TestChipsSystemPromptContainsGitHubSkill` (id-gate wins for SystemPrompt), `TestNonChipsCrewLackGitHubSkill` (no leakage across crew)

Refs #148 #153
