### PR TITLE
test(skills): close coverage gaps to bring package to 100% 🧪

### DIFF
--- a/internal/crew/skills/compose_test.go
+++ b/internal/crew/skills/compose_test.go
@@ -196,3 +196,74 @@ func TestComposePreservesPersonaTrimsTrailingNewlines(t *testing.T) {
 		t.Errorf("persona trim/separator wrong, got:\n%s", out)
 	}
 }
+
+// ----------------------------------------------------------------------
+// Non-ErrNotFound error paths in Compose. Closes coverage on the two
+// "compose: load universal:" / "compose: load profile:" branches that
+// only fire when a Source returns something that ISN'T ErrNotFound
+// (e.g. a permission-denied I/O error from a future filesystem-backed
+// source).
+// ----------------------------------------------------------------------
+
+// configurableSource is a test-only Source whose three methods return
+// the configured errors. Lets tests inject non-ErrNotFound errors at
+// any of the three Source entry points without touching real I/O.
+type configurableSource struct {
+	universal skills.Doc
+	universalErr error
+	skill skills.Doc
+	skillErr error
+	profile skills.Doc
+	profileErr error
+}
+
+func (c configurableSource) Universal() (skills.Doc, error) {
+	return c.universal, c.universalErr
+}
+
+func (c configurableSource) Skill(_ string) (skills.Doc, error) {
+	return c.skill, c.skillErr
+}
+
+func (c configurableSource) Profile(_ string) (skills.Doc, error) {
+	return c.profile, c.profileErr
+}
+
+func TestComposeUniversalNonNotFoundErrorIsPropagated(t *testing.T) {
+	// A non-ErrNotFound error from Universal must propagate as a
+	// "compose: load universal: <err>" error, NOT as ErrUniversalRequired
+	// (which is reserved for the missing-doc case).
+	src := configurableSource{universalErr: errors.New("permission denied")}
+	_, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, skills.ErrUniversalRequired) {
+		t.Error("non-ErrNotFound must NOT surface as ErrUniversalRequired")
+	}
+	if !strings.Contains(err.Error(), "compose: load universal") {
+		t.Errorf("expected compose: load universal prefix, got %v", err)
+	}
+}
+
+func TestComposeProfileNonNotFoundErrorIsPropagated(t *testing.T) {
+	// Universal + Skill succeed; Profile returns a non-ErrNotFound
+	// error. Compose must propagate as "compose: load profile <name>:"
+	// rather than silently skipping (skip-on-ErrNotFound is the soft
+	// path; other errors are hard).
+	src := configurableSource{
+		universal: skills.Doc{Content: "UNIV"},
+		skill:     skills.Doc{Content: "SKILL"},
+		profileErr: errors.New("permission denied"),
+	}
+	_, err := skills.Compose("PERSONA", []string{"github"}, src)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "compose: load profile") {
+		t.Errorf("expected compose: load profile prefix, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "github") {
+		t.Errorf("expected error to mention skill name github, got %v", err)
+	}
+}

--- a/internal/crew/skills/loader_internal_test.go
+++ b/internal/crew/skills/loader_internal_test.go
@@ -1,0 +1,78 @@
+package skills
+
+// Internal tests reaching unexported helpers (titleCase, readFromFS,
+// FilesystemSource.read) for branches that aren't naturally hit
+// through the public Source/Compose API. Each test pins a specific
+// branch the external test files cannot reach without fragile
+// real-world setup (permission-denied filesystems, root/non-root
+// dependencies).
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTitleCaseEmpty(t *testing.T) {
+	// Compose's per-skill section emits "## <Title> Workflow Rules"
+	// where <Title> is titleCase(name). A future caller passing an
+	// empty name would index runes[0] on an empty rune slice and
+	// panic — the empty-string guard returns "" instead. Callable
+	// here directly because the test is in the same package.
+	if got := titleCase(""); got != "" {
+		t.Errorf(`titleCase("") = %q, want ""`, got)
+	}
+}
+
+// errFS is a test-only fs.FS whose Open always returns the configured
+// error. Used to drive the non-ErrNotFound branch in readFromFS.
+type errFS struct{ err error }
+
+func (e errFS) Open(_ string) (fs.File, error) {
+	return nil, e.err
+}
+
+func TestReadFromFSNonNotFoundError(t *testing.T) {
+	// readFromFS must wrap ErrNotFound for missing files (covered by
+	// existing tests via embed.FS) AND propagate non-ErrNotFound
+	// errors (e.g. permission-denied) without rewriting them as
+	// ErrNotFound. Without this, a future fs.FS implementation that
+	// returns I/O errors would be silently misreported as missing.
+	const realErr = "synthetic-io-failure"
+	fsys := errFS{err: errors.New(realErr)}
+	_, err := readFromFS(fsys, "anything", "anything")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("non-ErrNotFound must NOT be wrapped as ErrNotFound")
+	}
+	if !strings.Contains(err.Error(), realErr) {
+		t.Errorf("expected underlying error preserved, got %v", err)
+	}
+}
+
+func TestFilesystemSourceReadNonNotFoundError(t *testing.T) {
+	// FilesystemSource.read must wrap ENOENT as ErrNotFound (covered
+	// by existing tests) AND propagate other I/O errors. Trigger by
+	// pointing Root at a regular file rather than a directory —
+	// filepath.Join + os.ReadFile then yields a non-ENOENT error
+	// ("not a directory" on Linux) the wrapper must NOT collapse to
+	// ErrNotFound.
+	dir := t.TempDir()
+	notADir := filepath.Join(dir, "regular-file")
+	if err := os.WriteFile(notADir, []byte("data"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	src := FilesystemSource{Root: notADir}
+	_, err := src.read("_universal.md")
+	if err == nil {
+		t.Fatal("expected error reading inside a regular file")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Errorf("non-ENOENT error must NOT be wrapped as ErrNotFound, got: %v", err)
+	}
+}

--- a/internal/crew/skills/loader_test.go
+++ b/internal/crew/skills/loader_test.go
@@ -354,3 +354,69 @@ func (e errSource) Skill(name string) (skills.Doc, error) { return skills.Doc{},
 func (e errSource) Profile(name string) (skills.Doc, error) {
 	return skills.Doc{}, e.err
 }
+
+// ----------------------------------------------------------------------
+// FallbackSource happy-path coverage for Universal and Profile
+// (Skill is already exercised; Universal and Profile previously only
+// hit the validate-error branch via TestFallbackSourceRejectsNil...).
+// ----------------------------------------------------------------------
+
+func TestFallbackSourceUniversalFallsBackToSecondary(t *testing.T) {
+	// Primary path doesn't exist → ErrNotFound → falls through to
+	// EmbeddedSource which has _universal.md.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	src := skills.FallbackSource{
+		Primary:   skills.FilesystemSource{Root: missing},
+		Secondary: skills.EmbeddedSource{},
+	}
+	doc, err := src.Universal()
+	if err != nil {
+		t.Fatalf("Universal: %v", err)
+	}
+	const sentinel = "Operator Intent Required"
+	if !strings.Contains(doc.Content, sentinel) {
+		t.Errorf("fallback Universal missing sentinel %q", sentinel)
+	}
+}
+
+func TestFallbackSourceProfileFallsBackToSecondary(t *testing.T) {
+	// Primary path doesn't exist → ErrNotFound → falls through to
+	// EmbeddedSource which has github/profile.md.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	src := skills.FallbackSource{
+		Primary:   skills.FilesystemSource{Root: missing},
+		Secondary: skills.EmbeddedSource{},
+	}
+	doc, err := src.Profile("github")
+	if err != nil {
+		t.Fatalf("Profile: %v", err)
+	}
+	const sentinel = "must not be exposed as callable tools"
+	if !strings.Contains(doc.Content, sentinel) {
+		t.Errorf("fallback Profile missing sentinel %q", sentinel)
+	}
+}
+
+func TestFallbackSourceProfileUsesPrimaryWhenPresent(t *testing.T) {
+	// Primary has profile.md with distinctive content → must win
+	// without falling through. Mirrors TestFallbackSourceUsesFilesystemWhenPresent
+	// for the Profile method.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "github"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "github", "profile.md"), []byte("OVERRIDE-PROFILE"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	src := skills.FallbackSource{
+		Primary:   skills.FilesystemSource{Root: dir},
+		Secondary: skills.EmbeddedSource{},
+	}
+	doc, err := src.Profile("github")
+	if err != nil {
+		t.Fatalf("Profile: %v", err)
+	}
+	if doc.Content != "OVERRIDE-PROFILE" {
+		t.Errorf("filesystem primary should win, got %q", doc.Content)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to merged PR #159, bringing `internal/crew/skills` from 90.4% to 100%. The gaps were inherited from PR1 (#151) — symbols with at least one branch never reached by any test. Operator coverage gate ("100% or pause for discussion") flagged this at #153 closeout; this PR closes the inherited debt before PR4's gate-flip arrives.

## Tests added

### External (`package skills_test`)

- **`TestComposeUniversalNonNotFoundErrorIsPropagated`** — Universal returning a non-`ErrNotFound` (e.g. permission-denied) must NOT surface as `ErrUniversalRequired`. Closes `compose.go:69`.
- **`TestComposeProfileNonNotFoundErrorIsPropagated`** — Profile returning non-`ErrNotFound` must propagate as `"compose: load profile %q"`, not be silently skipped. Closes `compose.go:86-88`.
- **`TestFallbackSourceUniversalFallsBackToSecondary`** — Primary missing → falls through to EmbeddedSource. Closes `loader.go:236`.
- **`TestFallbackSourceProfileFallsBackToSecondary`** — same shape for Profile. Closes `loader.go:255-257`.
- **`TestFallbackSourceProfileUsesPrimaryWhenPresent`** — mirror of the existing `Skill`-method primary-wins test for the Profile method.

New `configurableSource` test fixture in `compose_test.go`: Source whose three methods return configured `(Doc, error)` tuples — used by the two Compose error-path tests.

### Internal (`package skills`, new file `loader_internal_test.go`)

Two paths are unreachable from external tests without fragile permission-based filesystem setups (which misbehave under root). Internal tests handle them cleanly:

- **`TestTitleCaseEmpty`** — `titleCase("")` returns `""` without panicking on `[]rune("")[0]`. Unreachable externally because validation rejects empty names at every public `Source.Skill` / `Source.Profile` entry. Closes `compose.go:99-101`.
- **`TestReadFromFSNonNotFoundError`** — drive `readFromFS` via a custom `fs.FS` that returns `synthetic-io-failure`. Wrapper must preserve the error rather than collapse to `ErrNotFound`. Closes `loader.go:207`.
- **`TestFilesystemSourceReadNonNotFoundError`** — point `Root` at a regular file (not a directory) → `"not a directory"` on Linux, a non-ENOENT error the wrapper must NOT collapse to `ErrNotFound`. Closes `loader.go:160`. Internal test for symmetry with the `readFromFS` test (and to avoid root/non-root games).

## Coverage

| Symbol | Before | After |
|--------|--------|-------|
| `Compose` | 93.1% | **100%** |
| `titleCase` | 80.0% | **100%** |
| `FilesystemSource.read` | 85.7% | **100%** |
| `readFromFS` | 83.3% | **100%** |
| `FallbackSource.Universal` | 66.7% | **100%** |
| `FallbackSource.Profile` | 40.0% | **100%** |
| **package total** | 90.4% | **100%** |

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./...` clean
- [x] `CGO_ENABLED=0 go test -tags goolm -count=1 ./internal/...` — all 14 packages green
- [x] `go tool cover -func=...` confirms `internal/crew/skills` at 100% with every symbol at 100%

Refs #148 #153
