### PR TITLE
fix(ci): label override, lint guards, release-please defence-in-depth 🐛

### DIFF
--- a/.github/coverage-thresholds.yaml
+++ b/.github/coverage-thresholds.yaml
@@ -10,8 +10,13 @@
 # (#81/#86/#87/#88/#91/#121/#122) have all landed.
 #
 # Override: PRs that intentionally drop coverage (e.g. removing dead code)
-# can include [allow-coverage-drop] in the PR body to bypass the gate. The
-# CI run will still post the coverage delta as a comment for visibility.
+# can apply the `allow-coverage-drop` label to bypass the gate. The gate
+# still runs and posts the coverage delta as a comment; below-threshold
+# results become warnings instead of failures. Label add/remove events
+# automatically retrigger CI. The label is RBAC-gated (triage permission
+# or higher) — not author-self-service. See #163 for the design and the
+# parser-injection bug that motivated moving the override out of the PR
+# body.
 #
 # Repo-wide overall coverage is tracked under `total` (informational only,
 # not used for gating — per-package thresholds carry the security weight).

--- a/.github/scripts/comment-coverage-delta.sh
+++ b/.github/scripts/comment-coverage-delta.sh
@@ -195,7 +195,7 @@ main_profile="$(fetch_main_profile)"
 # it; otherwise create a new one.
 #
 # IMPORTANT: marker MUST remain a constant literal. It is interpolated into
-# the jq filter on line 200 via shell expansion. A dynamic value would
+# the jq filter below via shell expansion. A dynamic value would
 # re-introduce a parser-injection class bug (cf. #163). `readonly` is the
 # enforcement; the comment is the rationale.
 readonly marker='<!-- bridge-coverage-delta-comment -->'

--- a/.github/scripts/comment-coverage-delta.sh
+++ b/.github/scripts/comment-coverage-delta.sh
@@ -135,6 +135,12 @@ fetch_main_profile() {
 main_profile="$(fetch_main_profile)"
 
 # Build the comment body.
+#
+# Package names ($pkg) are Go module paths, character set [A-Za-z0-9_./-].
+# None of those collide with markdown table cell special chars (| or
+# newline) or backticks (used for code-formatting). If `per_package`'s
+# input source ever broadens beyond Go module paths, audit this
+# assumption and add escaping.
 # shellcheck disable=SC2016 # printf format strings contain literal backticks (markdown code-formatting), not command substitution
 {
     echo "## 📊 Coverage report"
@@ -179,7 +185,7 @@ main_profile="$(fetch_main_profile)"
     fi
 
     echo ""
-    echo "Thresholds enforced via \`.github/coverage-thresholds.yaml\`. Override with \`[allow-coverage-drop]\` in the PR body for deliberate drops."
+    echo "Thresholds enforced via \`.github/coverage-thresholds.yaml\`. Override with the \`allow-coverage-drop\` label for deliberate drops."
     echo ""
     echo "<sub>Posted by \`.github/scripts/comment-coverage-delta.sh\`. Best-effort; not gating.</sub>"
 } > /tmp/coverage-comment.md
@@ -187,7 +193,12 @@ main_profile="$(fetch_main_profile)"
 # Post (or update) the comment. We use a marker comment to avoid spamming
 # the PR on every push — find an existing comment with the marker and edit
 # it; otherwise create a new one.
-marker='<!-- bridge-coverage-delta-comment -->'
+#
+# IMPORTANT: marker MUST remain a constant literal. It is interpolated into
+# the jq filter on line 200 via shell expansion. A dynamic value would
+# re-introduce a parser-injection class bug (cf. #163). `readonly` is the
+# enforcement; the comment is the rationale.
+readonly marker='<!-- bridge-coverage-delta-comment -->'
 echo "$marker" >> /tmp/coverage-comment.md
 
 # Paginate the comments lookup. Default page size is 30; PRs that go through

--- a/.github/workflows/RELEASE-PLEASE.md
+++ b/.github/workflows/RELEASE-PLEASE.md
@@ -115,3 +115,113 @@ The Docker image uses a multi-stage build:
    and `-tags goolm` (no libolm C dependency)
 2. **Runtime stage** (`gcr.io/distroless/static:nonroot`): Minimal image, runs as
    non-root user (uid 65532)
+
+## Failure Modes and Recovery
+
+The release-please pipeline is mostly hands-off, but there are a handful of
+failure modes worth documenting before they bite. Each entry has a diagnostic
+and a recovery.
+
+### 1. Release PR fails to open after a merge
+
+**Symptom**: A conventional commit lands on `main`, but no release PR appears
+(or the existing release PR doesn't update to include it).
+
+**Diagnose**:
+- Check the `Release Please` workflow run for the merge commit. The
+  `release-please` job logs will show an action error (typically permissions
+  or a config parse error).
+- Verify `.github/workflows/release-please.yml` `permissions:` includes
+  `contents: write` and `pull-requests: write`.
+- Verify `release-please-config.json` parses (`jq . release-please-config.json`).
+
+**Recover**: Fix the underlying issue (revert the bad config commit or grant the
+missing permission) and re-run the workflow on the latest `main` commit (Actions
+tab → Re-run all jobs). release-please is idempotent on the commit history.
+
+### 2. Release PR is created but Docker push fails
+
+**Symptom**: `release_created == true` in the workflow logs, the GitHub Release
+exists with a tag, but the `docker` job in the same workflow run failed.
+
+**Diagnose**:
+- Check the `docker` job logs. Common causes: GHCR token transient failure,
+  build-push-action network timeout, validation step rejection (see entry 4).
+
+**Recover**: The release and Git tag are already created. Re-run **only the
+docker job** (Actions tab → failed run → Re-run failed jobs). The release-please
+step is a no-op the second time (`release_created` is sticky to the run).
+
+Do NOT delete and re-create the Git tag — the version is published on the GitHub
+Releases API and downstream consumers (if any) may have pinned it.
+
+### 3. Wrong version cut (alpha → beta promotion misconfigured)
+
+**Symptom**: A version was tagged with the wrong prerelease channel (e.g. a beta
+release came out as `0.2.0-alpha.1` because `release-please-config.json` was not
+updated when transitioning M2 → M3).
+
+**Diagnose**: Check `release-please-config.json` `prerelease-type` field against
+the intended phase from the Versioning Strategy table above.
+
+**Recover**: This is the hardest case because release-please's source of truth is
+`.release-please-manifest.json` plus the GitHub Releases API; both must agree.
+
+1. Delete the incorrectly-tagged GitHub Release via the UI (Releases page → ⋯ →
+   Delete). Do NOT delete the Git tag from the Releases page (the option does
+   both); delete only the Release.
+2. Delete the Git tag locally and on origin only if the bad tag was just pushed
+   and not yet consumed downstream: `git push origin :refs/tags/<bad-tag>`. If
+   downstream consumers may have pinned it, prefer leaving the tag and cutting a
+   new corrected version forward instead.
+3. Edit `release-please-config.json` to the correct `prerelease-type`.
+4. Edit `.release-please-manifest.json` to roll back to the last known-good
+   version (e.g. revert from `0.2.0-alpha.1` to `0.1.0-alpha.5`).
+5. Commit both edits with a conventional `chore:` commit.
+6. Wait for the next push to `main` (or push the chore commit) — release-please
+   will re-scan the commit history and reopen the release PR with the correct
+   channel.
+
+**Warning**: `.release-please-manifest.json` is the source-of-truth that
+release-please uses to decide what's next. If the manifest disagrees with the
+latest Release in the API, release-please can get stuck in a loop. Always edit
+both atomically.
+
+### 4. Validation step (`Validate release-please outputs`) rejects an output
+
+**Symptom**: `release-please` job logs show
+`::error::release-please version output '...' does not match expected SemVer pattern`
+or `::error::release-please tag_name '...' does not match expected 'vX.Y.Z'`.
+
+**Diagnose**: This means `googleapis/release-please-action@v4` emitted a value
+the workflow doesn't recognise. Two common causes:
+
+- `release-please-config.json` was changed to include a non-default `component`
+  or custom `separator`, which makes `tag_name` something other than
+  `v{semver}`.
+- A new release-please-action version (within the `@v4` major) changed output
+  formatting. Check the action's CHANGELOG against the deployed version.
+
+**Recover**:
+
+- If the config change was intentional (e.g. monorepo split is being introduced):
+  bump the validation regex in `.github/workflows/release-please.yml` to match
+  the new format and the local `tag_name` reconstruction logic in the docker
+  job's Summary step. Treat as a chore PR; touch both sites.
+- If the config change was accidental: revert it; the validation will pass on
+  the next run.
+- If the action's behaviour drifted: pin the action to a known-good minor
+  version (replace `@v4` with `@v4.4.1` etc.) until the upstream is verified.
+
+### 5. `tag_name` and `v${version}` disagree
+
+**Symptom**: Validation step fails with the second error variant above:
+`tag_name '...' does not match expected 'vX.Y.Z'`.
+
+**Diagnose**: This is a strict subset of case 4 — release-please-action emitted
+a tag_name with a component or non-standard separator. Bridge's
+`release-please-config.json` does not set those, so this would indicate either a
+config drift or an action-internal change.
+
+**Recover**: Same as case 4. The validation step is the protective layer; treat
+its rejection as success-of-the-guardrail rather than a failure to suppress.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `labeled` / `unlabeled` are added so adding the `allow-coverage-drop`
+    # label on a PR with an already-failed run retriggers CI immediately.
+    # Without them, the override label would only take effect on the next
+    # push (default types are `[opened, synchronize, reopened]`). The other
+    # three are listed explicitly because listing any types replaces the
+    # default set rather than augmenting it.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
 # 20 actions removed entirely 2026-09-16). Affected here: actions/checkout,
@@ -39,31 +46,43 @@ jobs:
             -covermode=atomic \
             ./internal/...
 
-      - name: Coverage check (per-package thresholds)
-        id: coverage_check
-        # The override marker `[allow-coverage-drop]` in a PR body bypasses
-        # the gate but still surfaces the result for visibility. Useful for
-        # deliberate refactors that remove dead code (and thus coverage).
+      - name: Coverage check (enforce)
+        # Per-package coverage gate. Fails the job if any tracked package
+        # falls below its threshold in coverage-thresholds.yaml. The
+        # override path lives in the next step.
         #
-        # `set -o pipefail` is explicit (GitHub Actions enables it by default
-        # in the runner shell, but `set +e` doesn't disable pipefail and we
-        # want the contract to survive any future runner config drift).
-        # Without it, `rc=$?` would capture `tee`'s exit code (always 0) and
-        # silently mask gate failures.
+        # `set -o pipefail` is explicit so the step exits with the script's
+        # rc rather than `tee`'s (always 0). The override decision is made
+        # by the GHA expression-language `if:` below — bash never sees the
+        # override signal, eliminating the PR-body-interpolation class of
+        # bug that bit #161.
+        if: >-
+          github.event_name != 'pull_request' ||
+          !contains(github.event.pull_request.labels.*.name, 'allow-coverage-drop')
+        run: |
+          set -o pipefail
+          .github/scripts/check-coverage.sh coverage.out | tee coverage-report.txt
+
+      - name: Coverage check (override warning)
+        # Operator override path: PR carries the `allow-coverage-drop`
+        # label. The gate still runs and surfaces the result for
+        # visibility, but a below-threshold result becomes a warning
+        # instead of a failure. The label is RBAC-gated (triage
+        # permission), so this override is not self-service for PR
+        # authors. Adding/removing the label retriggers CI via the
+        # `labeled`/`unlabeled` event types declared above.
+        if: >-
+          github.event_name == 'pull_request' &&
+          contains(github.event.pull_request.labels.*.name, 'allow-coverage-drop')
         run: |
           set +e
           set -o pipefail
           .github/scripts/check-coverage.sh coverage.out | tee coverage-report.txt
           rc=$?
-          set +o pipefail
           if [[ "$rc" -ne 0 ]]; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]] \
-                && grep -qF '[allow-coverage-drop]' <<< "${{ github.event.pull_request.body }}"; then
-              echo "::warning::coverage gate would have failed (rc=$rc) but [allow-coverage-drop] override is set"
-              exit 0
-            fi
-            exit "$rc"
+            echo "::warning::coverage gate would have failed (rc=$rc) but allow-coverage-drop label is set"
           fi
+          exit 0
 
       - name: Upload coverage profile
         # `if: always()` so the artefact is preserved even when the gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,17 @@ jobs:
           set -o pipefail
           .github/scripts/check-coverage.sh coverage.out | tee coverage-report.txt
           rc=$?
-          if [[ "$rc" -ne 0 ]]; then
+          # Only downgrade rc=1 (threshold miss — the expected gate
+          # failure) to a warning. rc=2+ indicates a script/config
+          # error (missing coverage profile, missing thresholds YAML,
+          # malformed YAML) that the override label is NOT meant to
+          # bypass; let it propagate so a CI misconfiguration can't
+          # slip through under cover of the override.
+          if [[ "$rc" -eq 1 ]]; then
             echo "::warning::coverage gate would have failed (rc=$rc) but allow-coverage-drop label is set"
+            exit 0
           fi
-          exit 0
+          exit "$rc"
 
       - name: Upload coverage profile
         # `if: always()` so the artefact is preserved even when the gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
           go-licenses check ./... \
             --disallowed_types=forbidden \
-            --ignore=$(go list -m | head -1)
+            --ignore="$(go list -m | head -1)"
 
           # Capture stderr so go-licenses diagnostics surface in CI
           # logs whether the step passes or fails. Silencing stderr

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,53 @@
+name: Lint Workflows
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+
+permissions:
+  contents: read
+
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Drop this env once affected
+# actions bump to Node-24-native versions.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  actionlint:
+    # Lints all workflows under .github/workflows/. Catches three classes
+    # of bug that surfaced as #163:
+    #
+    # 1. Unsafe interpolation of untrusted contexts (github.event.pull_request.body,
+    #    .title, .head.ref, etc.) into `run:` blocks.
+    # 2. Missing context references / typos in `${{ }}` expressions.
+    # 3. Malformed `if:` expressions and `types:` enumerations.
+    #
+    # Tag pinned for reproducibility — bump deliberately. The 1.7.x line is
+    # the current stable major; intermediate point releases are bugfix-only.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: -color
+
+  shellcheck:
+    # Lints all shell scripts under .github/scripts/. shellcheck is
+    # preinstalled on ubuntu-latest runners; no extra setup needed.
+    # Bridge has only two scripts today (check-coverage.sh and
+    # comment-coverage-delta.sh); the glob accommodates additions.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        run: shellcheck .github/scripts/*.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,10 +34,45 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Validate release-please outputs
+        # googleapis/release-please-action@v4 does NOT sanitise the
+        # `tag_name` and `version` outputs before calling setOutput().
+        # Component / separator from release-please-config.json flow
+        # through unmodified. Today's config produces v{semver}; this
+        # step fails loudly if release-please emits anything else,
+        # rather than letting an unexpected value land in a docker tag
+        # or step-summary markdown.
+        #
+        # Regex covers SemVer with optional `-<channel>[.<n>]` prerelease
+        # suffix (e.g. 1.2.3, 1.2.3-alpha, 1.2.3-alpha.1). Build-metadata
+        # (`+xxx`) is deliberately not accepted — bridge's config does
+        # not emit it; if it ever does, bump the regex deliberately.
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$ ]]; then
+            echo "::error::release-please version output '$VERSION' does not match expected SemVer pattern"
+            exit 1
+          fi
+          expected_tag="v${VERSION}"
+          if [[ "$TAG_NAME" != "$expected_tag" ]]; then
+            echo "::error::release-please tag_name '$TAG_NAME' does not match expected '$expected_tag' (release-please-config.json drift?)"
+            exit 1
+          fi
+          echo "release-please outputs validated: version=$VERSION tag=$TAG_NAME"
+
   docker:
     name: Build and Push Docker Image
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    # `== 'true'` is explicit. release_created is documented as the
+    # literal string "true" or "false"; the truthy-coercion form
+    # `if: ${{ ... }}` happens to work today but matches a different
+    # behaviour shape than the equivalent if a future GHA expression
+    # change tightens coercion.
+    if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -72,13 +107,22 @@ jobs:
           cache-from: type=gha
 
       - name: Summary
+        # version is validated upstream (see Validate release-please outputs
+        # in the release-please job). Tag is reconstructed locally as
+        # `v${VERSION}` rather than consuming the un-sanitised tag_name
+        # output — same value today, but removes the un-sanitised data
+        # path from the markdown-rendering surface.
+        env:
+          VERSION: ${{ needs.release-please.outputs.version }}
         run: |
-          echo "## Docker Image Published" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Version:** \`${{ needs.release-please.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Tag:** \`${{ needs.release-please.outputs.tag_name }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Pull:" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "docker pull ghcr.io/klazomenai/bridge:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Docker Image Published"
+            echo
+            echo "**Version:** \`$VERSION\`"
+            echo "**Tag:** \`v$VERSION\`"
+            echo
+            echo "Pull:"
+            echo '```'
+            echo "docker pull ghcr.io/klazomenai/bridge:$VERSION"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,12 @@ Where the rigging is dressed, every line in its place:
 - Domain: `domain:infra`, `domain:ai`, `domain:android`, `domain:matrix`,
   `domain:security`
 - Priority: `priority:high`, `priority:medium`, `priority:low`
+- Override: `allow-coverage-drop` — applied to a PR that intentionally
+  drops per-package test coverage (e.g. removing a tested code path
+  during a refactor). The gate still runs and posts the coverage delta
+  as a comment, but a below-threshold result becomes a warning instead
+  of a failure. Label add/remove retriggers CI automatically. RBAC-gated
+  (triage permission); not author-self-service.
 
 ## The Black Spot — Reporting Security Issues
 


### PR DESCRIPTION
## Summary

Implements all 6 acceptance criteria items from #163. The CI fragility surfaced by PR #161 was bash parsing the PR body via literal `${{ github.event.pull_request.body }}` substitution. This PR fixes that at source and adds guards so the class cannot reship.

- **Label-based coverage override** (Section 1 of #163 AC) — the override decision moves from PR-body marker to PR label (`allow-coverage-drop`). Bash never reads user-authored text. The injection class is eliminated. `on.pull_request.types` is extended to include `labeled`/`unlabeled` so label changes retrigger CI.
- **Lint guard** (Section 2) — new `lint-workflows.yml` runs `actionlint` and `shellcheck` on PRs touching `.github/**`. Regression net for the same class.
- **Coverage-delta script hardening** (Section 3) — `readonly` marker constant with inline rationale; explanatory comment on markdown-safe Go module paths; override text updated to reference the label.
- **release-please defence-in-depth** (Section 4) — validated finding: `release-please-action@v4` does NOT sanitise its `tag_name` / `version` outputs. New validation step regex-checks `version`; Summary step reconstructs `v${VERSION}` locally rather than consuming the un-sanitised `tag_name`; env-var indirection in the heredoc; `if:` on `release_created` tightened to `== 'true'`.
- **Recovery runbook** (Section 5) — RELEASE-PLEASE.md now has a "Failure modes and recovery" section covering 5 scenarios with diagnose + recover recipes.
- **Documentation cascade** (Section 6) — coverage-thresholds.yaml + CONTRIBUTING.md + comment-coverage-delta.sh in-comment text all point at the label.

The `allow-coverage-drop` label has been pre-created on the repo (out-of-band).

## Test plan

- [ ] CI green on this branch (the new `lint-workflows.yml` runs against the changed `ci.yml`, `release-please.yml`, and `comment-coverage-delta.sh` on its first run)
- [ ] `actionlint` clean across `.github/workflows/**`
- [ ] `shellcheck` clean on `.github/scripts/*.sh`
- [ ] `git grep '${{ github.event.pull_request.body }}'` returns no hits anywhere in `.github/`
- [ ] Scratch PR (post-merge) with a body containing the literal pattern `"close issue` plus a number reference and parens — CI runs cleanly with no bash parse error
- [ ] Scratch PR (post-merge) with a deliberate coverage drop on a tracked package:
  - Without the label: CI red (gate enforced)
  - Add the `allow-coverage-drop` label: CI retriggers, gate runs and posts the delta, fail becomes warning, job exits green
  - Remove the label: CI retriggers, gate goes back to enforcing, job red again
- [ ] First release-please run after merge produces correct Summary step output (manual eyeball)

## Open assumptions (devops review should validate)

1. `contains(github.event.pull_request.labels.*.name, 'allow-coverage-drop')` does exact-string per-element match (not substring/glob).
2. Listing `types: [opened, synchronize, reopened, labeled, unlabeled]` is the full enumeration; listing some types does not disable the others.
3. `actionlint` flags `${{ github.event.pull_request.body }}` in `run:` blocks as untrusted-context-in-shell.
4. `rhysd/actionlint:1.7.7` is a valid Docker Hub tag and works as `uses: docker://...`.
5. `docker/build-push-action@v6` `tags:` input is safe from shell injection (action input, not shell run-block).

## Scope OUT (deferred follow-ups)

- Replacing `googleapis/release-please-action` with a different tool
- Pinning the action to a SHA (separate supply-chain ticket)
- Fixing the substring-match imprecision on the "Push latest tag" `if:` at release-please.yml (file as correctness tidy follow-up)
- bats / `act` testing harnesses
- Touching `license-audit`, `docker:` job in ci.yml, or `check-coverage.sh` awk parser
- Strengthening `no-closes-in-*.sh` hooks to catch the loose `Closes ... #N` form (separate hook-design ticket)

Plan reference: `~/.claude/plans/silly-squishing-leaf.md`

Refs #163
