### PR TITLE
test(crew): complete #154 L2 enforcement test roster 🧪

### DIFF
--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -747,7 +747,11 @@ func TestChipsPromptContainsUniversalRules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load real crew.yaml: %v", err)
 	}
-	prompt := r.Get("chips").SystemPrompt()
+	chips := r.Get("chips")
+	if chips == nil {
+		t.Fatal("chips not found in real crew.yaml")
+	}
+	prompt := chips.SystemPrompt()
 	for _, fragment := range []string{
 		"Allowlist is fail-closed",
 		"Operator Intent Required",
@@ -775,7 +779,11 @@ func TestChipsPromptContainsGitHubProfileRules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load real crew.yaml: %v", err)
 	}
-	prompt := r.Get("chips").SystemPrompt()
+	chips := r.Get("chips")
+	if chips == nil {
+		t.Fatal("chips not found in real crew.yaml")
+	}
+	prompt := chips.SystemPrompt()
 	for _, fragment := range []string{
 		"must not be exposed as callable tools",
 		"NEVER autonomously resolve Copilot review threads",

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -736,7 +736,7 @@ func TestChipsSystemPromptContainsGitHubSkill(t *testing.T) {
 //
 // The test asserts on the full composed prompt regardless of source,
 // since the prompt is what's shipped to the model. Plus a worked-example
-// stability anchor ("close issue 99") that catches subtle re-wraps in
+// stability anchor ("close issue #99") that catches subtle re-wraps in
 // the universal-addendum file.
 func TestChipsPromptContainsUniversalRules(t *testing.T) {
 	const configPath = "../../config/crew.yaml"

--- a/internal/crew/registry_test.go
+++ b/internal/crew/registry_test.go
@@ -724,17 +724,21 @@ func TestChipsSystemPromptContainsGitHubSkill(t *testing.T) {
 	}
 }
 
-// TestChipsSystemPromptContainsOperatorIntentRule is one of the four L2
-// enforcement tests filed against the #148 epic. Asserts that the
-// universal addendum's "Operator Intent Required" section is composed
-// into Chips' system prompt so chips sees the rule at every turn —
-// mutations must reflect intent in the operator's most recent message,
-// and the pending-confirmation exception is documented with its worked
-// example ("close issue #99" → "Confirm?" → "yes").
+// TestChipsPromptContainsUniversalRules verifies that the four universal-rule
+// sentinels enumerated in #154's AC are composed into Chips's system prompt.
+// Loads the real config/crew.yaml so a divergence between the embedded
+// skill content and the AC contract is caught at build time.
 //
-// Loads the real config/crew.yaml so a divergence between the YAML's
-// declared skills and the embedded universal addendum is caught.
-func TestChipsSystemPromptContainsOperatorIntentRule(t *testing.T) {
+// Sentinels come from two source files (per Compose's output ordering):
+//   - "Allowlist is fail-closed", "Operator Intent Required",
+//     "Pending-confirmation exception" → embedded/_universal.md
+//   - "Refused outright" → embedded/github/profile.md
+//
+// The test asserts on the full composed prompt regardless of source,
+// since the prompt is what's shipped to the model. Plus a worked-example
+// stability anchor ("close issue 99") that catches subtle re-wraps in
+// the universal-addendum file.
+func TestChipsPromptContainsUniversalRules(t *testing.T) {
 	const configPath = "../../config/crew.yaml"
 	if _, err := os.Stat(configPath); err != nil {
 		t.Skipf("config/crew.yaml not found at %s (running outside repo?)", configPath)
@@ -745,12 +749,69 @@ func TestChipsSystemPromptContainsOperatorIntentRule(t *testing.T) {
 	}
 	prompt := r.Get("chips").SystemPrompt()
 	for _, fragment := range []string{
-		"Write Operations — Operator Intent Required",
+		"Allowlist is fail-closed",
+		"Operator Intent Required",
+		"Refused outright",
 		"Pending-confirmation exception",
-		"close issue #99", // worked example anchoring the rule
+		"close issue #99", // worked-example stability anchor (verbatim from _universal.md)
 	} {
 		if !strings.Contains(prompt, fragment) {
-			t.Errorf("chips prompt missing operator-intent fragment %q", fragment)
+			t.Errorf("chips prompt missing universal-rule sentinel %q", fragment)
+		}
+	}
+}
+
+// TestChipsPromptContainsGitHubProfileRules verifies that the three github
+// profile-addendum sentinels enumerated in #154's AC are composed into
+// Chips's system prompt. These rules sit in embedded/github/profile.md
+// (the per-skill operator-overlay) and gate Chips's github-specific
+// write-surface discipline.
+func TestChipsPromptContainsGitHubProfileRules(t *testing.T) {
+	const configPath = "../../config/crew.yaml"
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("config/crew.yaml not found at %s (running outside repo?)", configPath)
+	}
+	r, err := crew.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load real crew.yaml: %v", err)
+	}
+	prompt := r.Get("chips").SystemPrompt()
+	for _, fragment := range []string{
+		"must not be exposed as callable tools",
+		"NEVER autonomously resolve Copilot review threads",
+		"Refused outright",
+	} {
+		if !strings.Contains(prompt, fragment) {
+			t.Errorf("chips prompt missing github-profile sentinel %q", fragment)
+		}
+	}
+}
+
+// TestNonChipsCrewLackUniversal verifies the universal addendum is gated to
+// crew with declared skills. Maren / Crest / Bosun / Lookout have no skills
+// in config/crew.yaml, so their system prompts must not contain the
+// Compose-emitted "## Operator Universal Rules" section header. The
+// universal addendum is the gate the operator-intent + allowlist + refused-
+// outright rules sit under; surfacing it on read-only crew would over-
+// constrain personas that have no mutation surface to gate.
+func TestNonChipsCrewLackUniversal(t *testing.T) {
+	const configPath = "../../config/crew.yaml"
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("config/crew.yaml not found at %s (running outside repo?)", configPath)
+	}
+	r, err := crew.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load real crew.yaml: %v", err)
+	}
+	const universalHeader = "## Operator Universal Rules"
+	for _, id := range []string{"maren", "crest", "bosun", "lookout"} {
+		c := r.Get(id)
+		if c == nil {
+			t.Errorf("%s not found in real crew.yaml", id)
+			continue
+		}
+		if strings.Contains(c.SystemPrompt(), universalHeader) {
+			t.Errorf("%s system prompt unexpectedly contains universal-addendum header — gating broken", id)
 		}
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1219,10 +1219,11 @@ func TestChipsRefusesNonAllowlistedRepo(t *testing.T) {
 // declared skills and the embedded universal addendum is caught.
 //
 // AC sentinel from #154 is "Every write operation must reflect intent in
-// the operator's most recent message". That literal is hard-wrapped
-// between "recent" and "message" in _universal.md (lines 40-41), so the
-// test asserts on the single-line prefix to be robust against future
-// re-wraps that preserve semantic meaning.
+// the operator's most recent message". The sentence is hard-wrapped
+// inside the "Write Operations — Operator Intent Required" section of
+// _universal.md (the wrap currently falls between "recent" and
+// "message"); the test asserts on the single-line prefix to be robust
+// against future re-wraps that preserve semantic meaning.
 //
 // Lives in the orchestrator package per #154 AC. Functionally a
 // prompt-content test; companions in internal/crew/registry_test.go

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1236,7 +1236,11 @@ func TestChipsRefusesMutationWithoutOperatorIntent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load real crew.yaml: %v", err)
 	}
-	prompt := reg.Get("chips").SystemPrompt()
+	chips := reg.Get("chips")
+	if chips == nil {
+		t.Fatal("chips not found in real crew.yaml")
+	}
+	prompt := chips.SystemPrompt()
 	const sentinel = "Every write operation must reflect intent in the operator's most recent"
 	if !strings.Contains(prompt, sentinel) {
 		t.Errorf("chips SystemPrompt missing operator-intent sentinel %q", sentinel)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,10 +1,12 @@
 package orchestrator_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1211,6 +1213,36 @@ func TestChipsRefusesNonAllowlistedRepo(t *testing.T) {
 	}
 }
 
+// TestChipsRefusesMutationWithoutOperatorIntent verifies that the universal
+// addendum's operator-intent rule is composed into Chips's system prompt.
+// Loads the real config/crew.yaml so a divergence between the YAML's
+// declared skills and the embedded universal addendum is caught.
+//
+// AC sentinel from #154 is "Every write operation must reflect intent in
+// the operator's most recent message". That literal is hard-wrapped
+// between "recent" and "message" in _universal.md (lines 40-41), so the
+// test asserts on the single-line prefix to be robust against future
+// re-wraps that preserve semantic meaning.
+//
+// Lives in the orchestrator package per #154 AC. Functionally a
+// prompt-content test; companions in internal/crew/registry_test.go
+// cover the universal-rules + github-profile-rules sentinels.
+func TestChipsRefusesMutationWithoutOperatorIntent(t *testing.T) {
+	const configPath = "../../config/crew.yaml"
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("config/crew.yaml not found at %s (running outside repo?)", configPath)
+	}
+	reg, err := crew.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load real crew.yaml: %v", err)
+	}
+	prompt := reg.Get("chips").SystemPrompt()
+	const sentinel = "Every write operation must reflect intent in the operator's most recent"
+	if !strings.Contains(prompt, sentinel) {
+		t.Errorf("chips SystemPrompt missing operator-intent sentinel %q", sentinel)
+	}
+}
+
 // TestPendingConfirmationExceptionAccepts drives the pending-confirmation
 // exception path from _universal.md: operator proposes a mutation, the
 // orchestrator surfaces a confirm prompt with no tool_use, the operator
@@ -1225,8 +1257,24 @@ func TestChipsRefusesNonAllowlistedRepo(t *testing.T) {
 // refuse the bare "yes" without the prior turn. The prompt-content
 // guarantee (chips sees the Operator Intent rule + worked example) is
 // covered in the companion crew test.
+//
+// Audit-log assertion: the test redirects slog.Default to a buffer so
+// the "audit: tool invoked" line emitted by sandbox.go (when the
+// mutation tool fires) is captured. SandboxMeta.Logger is unset by
+// the orchestrator's executeToolCalls path; ExecuteWithSandbox falls
+// back to slog.Default(), so swapping the default routes audit lines
+// here. NOT t.Parallel-safe — bridge orchestrator tests are not
+// parallel today; if that changes, refactor to a SandboxConfig.Logger
+// field.
 func TestPendingConfirmationExceptionAccepts(t *testing.T) {
 	defer testutil.VerifyNone(t)
+
+	// Capture audit-log output for the duration of this test.
+	var buf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+
 	mt := &mutationTool{}
 	toolReg := tools.NewRegistry()
 	toolReg.Register(&tools.DelegateTool{})
@@ -1283,5 +1331,20 @@ func TestPendingConfirmationExceptionAccepts(t *testing.T) {
 	// Sanity: 3 mock calls total — turn 1 (1) + turn 2 (initial + post-tool, 2).
 	if got := len(mock.calls); got != 3 {
 		t.Errorf("expected 3 total mock calls (turn 1 + turn 2 with tool loop), got %d", got)
+	}
+
+	// Audit-log assertion: the mutation tool's execution must have
+	// emitted an "audit: tool invoked" record with mutation:true and
+	// the tool name. sandbox.go (line 110) uses slog.Info; we redirected
+	// slog.Default above, so the record landed in our buffer.
+	auditLog := buf.String()
+	for _, want := range []string{
+		"audit: tool invoked",
+		`"mutation":true`,
+		`"tool":"test_mutation"`,
+	} {
+		if !strings.Contains(auditLog, want) {
+			t.Errorf("expected audit log to contain %q; got:\n%s", want, auditLog)
+		}
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1339,8 +1339,10 @@ func TestPendingConfirmationExceptionAccepts(t *testing.T) {
 
 	// Audit-log assertion: the mutation tool's execution must have
 	// emitted an "audit: tool invoked" record with mutation:true and
-	// the tool name. sandbox.go (line 110) uses slog.Info; we redirected
-	// slog.Default above, so the record landed in our buffer.
+	// the tool name. ExecuteWithSandbox emits via slog.Info on the
+	// per-meta Logger (falling back to slog.Default when meta.Logger
+	// is nil); we redirected slog.Default above, so the record landed
+	// in our buffer.
 	auditLog := buf.String()
 	for _, want := range []string{
 		"audit: tool invoked",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1113,11 +1113,16 @@ func TestHandle400MidLoopNoRecovery(t *testing.T) {
 // =====================================================================
 // L2 enforcement roster (#154)
 //
-// Two of the four L2 tests for the #148 epic live here. Companion tests:
-//   - internal/crew/registry_test.go::TestChipsSystemPromptContainsOperatorIntentRule
-//     — Compose output carries the Operator Intent rule and worked example
-//   - internal/tools/chips/chips_test.go::TestProductionChipsRegistryHasNoMergeTools
-//     — gh_pr_merge / gh_pr_ready are not registered
+// Tests in this file cover the orchestrator-layer L2 enforcement
+// assertions on #154's AC: allowlist refusal, mutation-without-operator-
+// intent (prompt-content), and pending-confirmation exception (with
+// audit-log emission). Companion tests live in:
+//   - internal/crew/registry_test.go (universal-rules + github-profile +
+//     non-chips-lack-universal prompt-content)
+//   - internal/tools/registry_test.go::TestGhPrMergeNotRegistered
+//     (gh_pr_merge / gh_pr_ready not in the production chips registry)
+//   - internal/tools/sandbox_test.go (audit-log emission + token
+//     redaction on the mutation:true path)
 // =====================================================================
 
 const chipsTestCrewYAML = `

--- a/internal/tools/chips/chips_test.go
+++ b/internal/tools/chips/chips_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"klazomenai/bridge/internal/tools"
 	"klazomenai/bridge/internal/tools/chips"
 )
 
@@ -479,39 +478,3 @@ func TestTokenSanitisedInOutput(t *testing.T) {
 	}
 }
 
-// --- L2 enforcement: registration roster (#154) ---
-
-// TestProductionChipsRegistryHasNoMergeTools is one of the four L2
-// enforcement tests filed against the #148 epic. Builds the production
-// chips registry via RegisterChipsTools and asserts the high-risk
-// mutations gh_pr_merge and gh_pr_ready are not registered. Those tools
-// are reserved as human decisions per the operator's standing rule;
-// _universal.md requires they not be callable at all rather than gated
-// at execute time (which would be bypassable via prompt injection).
-//
-// Companion tests in other packages cover the prompt-content rule
-// (internal/crew) and runtime allowlist refusal (internal/orchestrator).
-func TestProductionChipsRegistryHasNoMergeTools(t *testing.T) {
-	reg := tools.NewRegistry()
-	chips.RegisterChipsTools(
-		reg,
-		chips.DefaultExecFn(),
-		chips.ParseRepoAllowlist("klazomenai/bridge"),
-		"test-token",
-	)
-	for _, forbidden := range []string{"gh_pr_merge", "gh_pr_ready"} {
-		if reg.Has(forbidden) {
-			t.Errorf("production chips registry has %q — high-risk mutation must not be registered", forbidden)
-		}
-	}
-	// Anchor the roster's positive shape so a future deletion of
-	// RegisterChipsTools wouldn't silently turn this into a vacuous test.
-	for _, expected := range []string{
-		"gh_issue_list", "gh_issue_view", "gh_pr_list",
-		"gh_pr_view", "gh_pr_checks", "git_log", "git_diff",
-	} {
-		if !reg.Has(expected) {
-			t.Errorf("production chips registry missing expected tool %q", expected)
-		}
-	}
-}

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -8,6 +8,7 @@ import (
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 
 	"klazomenai/bridge/internal/tools"
+	chipstools "klazomenai/bridge/internal/tools/chips"
 )
 
 // stubTool is a minimal ToolDefinition for testing.
@@ -208,5 +209,44 @@ func TestIsMutation(t *testing.T) {
 				t.Errorf("IsMutation(%T) = %v, want %v", tc.tool, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestGhPrMergeNotRegistered is one of the L2 enforcement tests on #154's AC.
+// Builds the production chips registry via the real RegisterChipsTools
+// entrypoint and asserts the high-risk mutations gh_pr_merge and
+// gh_pr_ready are not registered. Those tools are reserved as human
+// decisions per the operator's standing rule; _universal.md requires
+// they not be callable at all rather than gated at execute time (which
+// would be bypassable via prompt injection).
+//
+// Lives in internal/tools/registry_test.go per AC; uses the external
+// tools_test package so importing chipstools forms only a one-way
+// dependency (tools_test → chipstools → tools), no cycle.
+//
+// Companion tests in other packages cover the prompt-content rule
+// (internal/crew) and runtime allowlist refusal (internal/orchestrator).
+func TestGhPrMergeNotRegistered(t *testing.T) {
+	reg := tools.NewRegistry()
+	chipstools.RegisterChipsTools(
+		reg,
+		chipstools.DefaultExecFn(),
+		chipstools.ParseRepoAllowlist("klazomenai/bridge"),
+		"test-token",
+	)
+	for _, forbidden := range []string{"gh_pr_merge", "gh_pr_ready"} {
+		if reg.Has(forbidden) {
+			t.Errorf("production chips registry has %q — high-risk mutation must not be registered", forbidden)
+		}
+	}
+	// Anchor the roster's positive shape so a future deletion of
+	// RegisterChipsTools wouldn't silently turn this into a vacuous test.
+	for _, expected := range []string{
+		"gh_issue_list", "gh_issue_view", "gh_pr_list",
+		"gh_pr_view", "gh_pr_checks", "git_log", "git_diff",
+	} {
+		if !reg.Has(expected) {
+			t.Errorf("production chips registry missing expected tool %q", expected)
+		}
 	}
 }

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -227,7 +227,42 @@ func TestAuditRecordEmittedOnInvocation(t *testing.T) {
 	}
 }
 
-func TestAuditRecordRedactsSecrets(t *testing.T) {
+// TestAuditRecordEmittedOnWrite is one of the L2 enforcement tests on
+// #154's AC. Exercises the mutation:true code path through
+// ExecuteWithSandbox; asserts the audit-log record carries the
+// mutation flag, the tool name, and a redacted argv. Companion to the
+// broader TestAuditRecordEmittedOnInvocation which exercises the
+// mutation:false (read-only) case.
+func TestAuditRecordEmittedOnWrite(t *testing.T) {
+	logger, buf := auditLogger()
+	tool := &testTool{name: "ok", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "result", nil
+	}}
+	meta := tools.SandboxMeta{
+		CrewID:   "chips",
+		RoomID:   "!room:localhost",
+		ToolName: "gh_issue_close",
+		Mutation: true,
+		Logger:   logger,
+	}
+	input := json.RawMessage(`{"org":"klazomenai","repo":"bridge","issue":42}`)
+
+	tools.ExecuteWithSandbox(context.Background(), tool, input, tools.DefaultSandboxConfig(), meta)
+
+	out := buf.String()
+	for _, want := range []string{
+		`"msg":"audit: tool invoked"`,
+		`"tool":"gh_issue_close"`,
+		`"mutation":true`,
+		`"argv_redacted"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("audit log missing %q\nfull buffer:\n%s", want, out)
+		}
+	}
+}
+
+func TestAuditRecordRedactsTokens(t *testing.T) {
 	logger, buf := auditLogger()
 	tool := &testTool{name: "ok", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {
 		return "ok", nil

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -230,9 +230,12 @@ func TestAuditRecordEmittedOnInvocation(t *testing.T) {
 // TestAuditRecordEmittedOnWrite is one of the L2 enforcement tests on
 // #154's AC. Exercises the mutation:true code path through
 // ExecuteWithSandbox; asserts the audit-log record carries the
-// mutation flag, the tool name, and a redacted argv. Companion to the
-// broader TestAuditRecordEmittedOnInvocation which exercises the
-// mutation:false (read-only) case.
+// mutation flag, the tool name, and the presence of the argv_redacted
+// field. (Actual redaction behaviour is exercised separately by
+// TestAuditRecordRedactsTokens — this test does not configure
+// SandboxMeta.Secrets.) Companion to the broader
+// TestAuditRecordEmittedOnInvocation which exercises the mutation:false
+// (read-only) case.
 func TestAuditRecordEmittedOnWrite(t *testing.T) {
 	logger, buf := auditLogger()
 	tool := &testTool{name: "ok", execFn: func(_ context.Context, _ json.RawMessage) (string, error) {


### PR DESCRIPTION
## Summary

Completes the L2 enforcement test roster called for by #154. No production code change — pure test additions and one move-and-rename. After this PR merges, #154 should be 100% closeable.

- **Crew-package L2 tests** (`internal/crew/registry_test.go`): `TestChipsPromptContainsUniversalRules` (renamed + expanded sentinel set from 2 → 4), `TestChipsPromptContainsGitHubProfileRules` (new), `TestNonChipsCrewLackUniversal` (new).
- **Orchestrator L2 tests** (`internal/orchestrator/orchestrator_test.go`): `TestChipsRefusesMutationWithoutOperatorIntent` (new prompt-content test — uses the single-line prefix of the hard-wrapped operator-intent sentence in `_universal.md`); `TestPendingConfirmationExceptionAccepts` augmented with an audit-log assertion (slog.Default swap + buffer-backed JSONHandler).
- **Tools-registry L2 test** (`internal/tools/registry_test.go`): `TestGhPrMergeNotRegistered` (moved + renamed from `TestProductionChipsRegistryHasNoMergeTools` in `internal/tools/chips/chips_test.go`).
- **Sandbox audit tests** (`internal/tools/sandbox_test.go`): `TestAuditRecordEmittedOnWrite` (new — mutation:true case), `TestAuditRecordRedactsTokens` (renamed from `TestAuditRecordRedactsSecrets` per AC name).

## Test plan

- [ ] CI green (test + license-audit + lint-workflows + docker)
- [ ] `git grep 'TestChipsPromptContainsUniversalRules'` finds it in `internal/crew/registry_test.go`
- [ ] `git grep 'TestChipsPromptContainsGitHubProfileRules'` finds it in `internal/crew/registry_test.go`
- [ ] `git grep 'TestNonChipsCrewLackUniversal'` finds it in `internal/crew/registry_test.go`
- [ ] `git grep 'TestChipsRefusesMutationWithoutOperatorIntent'` finds it in `internal/orchestrator/orchestrator_test.go`
- [ ] `git grep 'TestGhPrMergeNotRegistered'` finds it in `internal/tools/registry_test.go`
- [ ] `git grep 'TestProductionChipsRegistryHasNoMergeTools'` returns no hits (moved + renamed)
- [ ] `git grep 'TestAuditRecordEmittedOnWrite'` finds it in `internal/tools/sandbox_test.go`
- [ ] `git grep 'TestAuditRecordRedactsTokens'` finds it in `internal/tools/sandbox_test.go`
- [ ] Coverage: `internal/crew` 100%, `internal/crew/skills` 100%, `internal/orchestrator` 94.4%, `internal/tools` 90.1%, `internal/tools/chips` ≥ 80% (drops from 87.9% to 82.8% because the moved test no longer runs from the chips package; still above threshold)
- [ ] After merge: walk #154 AC against evidence and close with verification table

## Notes

- The AC sentinel `Every write operation must reflect intent in the operator's most recent message` is hard-wrapped between "recent" and "message" in `_universal.md` (lines 40-41). The test uses the single-line prefix `Every write operation must reflect intent in the operator's most recent` to be robust against future re-wraps that preserve semantic meaning. Documented in the test's doc-comment.
- `TestPendingConfirmationExceptionAccepts` swaps `slog.Default` to capture the audit-log line. Not `t.Parallel`-safe — bridge's orchestrator tests are not parallel today. If parallel adoption arrives, refactor to a `SandboxConfig.Logger` field. Documented in the test's doc-comment.
- The `internal/tools/chips` package coverage drops from 87.9% to 82.8% because `TestGhPrMergeNotRegistered` moved out of `chips_test` and into `tools_test` per AC location. Above-threshold (80%); the moved test still exercises `RegisterChipsTools` from `tools_test`.

Closes #154
