### PR TITLE
feat(build): bake dotfiles bundle into image + drift CI 🏗️

### DIFF
--- a/.github/workflows/skills-drift.yml
+++ b/.github/workflows/skills-drift.yml
@@ -1,0 +1,85 @@
+name: Skills Drift
+
+# Catches mismatches between internal/crew/skills/embedded/ (the binary's
+# runtime fallback) and the klazomenai/dotfiles ref pinned in
+# Dockerfile's ARG DOTFILES_REF. Fires on PR diff to either side of
+# the contract, plus a weekly schedule so a forgotten bump elsewhere
+# doesn't sit unnoticed.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/crew/skills/embedded/**'
+      - 'Dockerfile'
+  schedule:
+    # Monday 09:00 UTC — early-week visibility before active development.
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: read
+
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02
+# (Node 20 actions removed entirely 2026-09-16). Drop this env once
+# affected actions bump to Node-24-native versions.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  drift:
+    name: Embedded vs dotfiles drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract DOTFILES_REF from Dockerfile
+        # Fail loudly if the ARG is missing or not a 40-char hex SHA.
+        # Branch-name / tag refs would silently re-resolve on each
+        # run, defeating the drift gate; the bump ceremony requires a
+        # full SHA per CONTRIBUTING.md.
+        run: |
+          ref=$(awk -F'=' '/^ARG DOTFILES_REF=/ { print $2; exit }' Dockerfile | tr -d ' "')
+          if [[ -z "$ref" ]]; then
+            echo "::error::DOTFILES_REF ARG not found in Dockerfile"
+            exit 1
+          fi
+          if ! [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::DOTFILES_REF='${ref}' is not a 40-char git SHA"
+            exit 1
+          fi
+          echo "DOTFILES_REF=${ref}" >> "$GITHUB_ENV"
+          echo "Using DOTFILES_REF=${ref}"
+
+      - name: Clone klazomenai/dotfiles at pinned SHA
+        run: |
+          mkdir /tmp/dotfiles
+          cd /tmp/dotfiles
+          git init -q
+          git remote add origin https://github.com/Klazomenai/dotfiles
+          git fetch -q --depth=1 origin "$DOTFILES_REF"
+          git checkout -q FETCH_HEAD
+
+      - name: Diff embedded vs dotfiles
+        run: |
+          set -e
+          fail=0
+          for pair in \
+              "internal/crew/skills/embedded/_universal.md:/tmp/dotfiles/claude/profiles/_universal.md" \
+              "internal/crew/skills/embedded/github/SKILL.md:/tmp/dotfiles/claude/skills/github/SKILL.md" \
+              "internal/crew/skills/embedded/github/profile.md:/tmp/dotfiles/claude/profiles/github.md"; do
+            ours="${pair%:*}"
+            theirs="${pair#*:}"
+            if ! diff -q "$ours" "$theirs" > /dev/null 2>&1; then
+              echo "::error file=${ours}::drift detected vs dotfiles@${DOTFILES_REF}"
+              diff -u "$ours" "$theirs" || true
+              fail=1
+            fi
+          done
+          if [[ "$fail" -eq 1 ]]; then
+            echo
+            echo "To resolve: clone klazomenai/dotfiles at DOTFILES_REF=${DOTFILES_REF},"
+            echo "then run 'make sync-skills' (from the bridge repo root) and commit the"
+            echo "updated embedded/ files. Or revert the DOTFILES_REF bump in the"
+            echo "Dockerfile if the embedded content is the desired state."
+            exit 1
+          fi
+          echo "No drift: embedded/ matches dotfiles@${DOTFILES_REF}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ To bump the dotfiles ref:
    `chore/<issue>-bump-dotfiles-ref`, commit, draft PR. The skills-drift
    CI catches a bump-without-rebundle (and vice versa).
 4. **Verify locally before push** — `git diff internal/crew/skills/embedded/`
-   shows the expected content delta; `go test -tags goolm ./internal/crew/...`
+   shows the expected content delta; `CGO_ENABLED=0 go test -tags goolm ./internal/crew/...`
    stays green (no test fixtures are pinned to old content).
 
 The bump should be **deliberate and reviewable** — the embedded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,23 +71,43 @@ diverge from the supported build path.
 
 CI will run the full test suite plus license-audit checks on every PR.
 
-### Re-syncing the Chips skill body
+### Bumping `DOTFILES_REF`
 
-Chips' system prompt is augmented at build time with a curated subset of the
-operator's `github` skill, vendored at `internal/crew/skills/github.md` and
-embedded via `go:embed`. To re-sync from a local dotfiles checkout:
+Chips' system prompt is composed at runtime from three files sourced
+from `klazomenai/dotfiles` and bundled two ways:
 
-```bash
-cp ../dotfiles/claude/skills/github/SKILL.md internal/crew/skills/github.md
-# then hand-curate: strip the public-repo-sanitisation section, drop frontmatter,
-# leave the workflow rules. Diff before committing.
-```
+- **Embedded fallback** (the runtime source-of-truth): the three files
+  live under `internal/crew/skills/embedded/` and are `go:embed`ded
+  into the bridge binary at build time.
+- **Image-baked copy** (operator-inspectable): the same three files
+  are also placed under `/var/lib/klazomenai/skills/` in the runtime
+  container image, sourced directly from `klazomenai/dotfiles` at the
+  pinned `DOTFILES_REF` in `Dockerfile`.
 
-The sync is intentionally manual: the upstream skill targets human operators
-running Claude Code, and the embedded copy targets an autonomous orchestrator —
-sections need triage rather than blind copy. The
-`TestChipsSystemPromptContainsGitHubSkill` golden test catches accidental
-truncation.
+The two paths must agree. The `skills-drift` CI workflow
+(`.github/workflows/skills-drift.yml`) fails any PR where they
+diverge — either side moving requires the other to move in lockstep.
+
+To bump the dotfiles ref:
+
+1. **Bump the pin in `Dockerfile`** — edit the `ARG DOTFILES_REF=...`
+   line in the `dotfiles` stage to the new full 40-char git SHA on
+   `klazomenai/dotfiles` main.
+2. **Re-bundle the embedded fallback** — from a sibling
+   `klazomenai/dotfiles` checkout (cloned to `../dotfiles/`, or set
+   `DOTFILES_DIR=/path/to/dotfiles`), run `make sync-skills`. This
+   copies the three files into `internal/crew/skills/embedded/`.
+3. **Commit both edits in one PR** — branch
+   `chore/<issue>-bump-dotfiles-ref`, commit, draft PR. The skills-drift
+   CI catches a bump-without-rebundle (and vice versa).
+4. **Verify locally before push** — `git diff internal/crew/skills/embedded/`
+   shows the expected content delta; `go test -tags goolm ./internal/crew/...`
+   stays green (no test fixtures are pinned to old content).
+
+The bump should be **deliberate and reviewable** — the embedded
+content shapes Chips's runtime behaviour, and any sentinel-string
+changes risk breaking the L2 enforcement tests. Don't bundle a
+DOTFILES_REF bump with unrelated feature work.
 
 ## The Quartermaster's Conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,33 @@ RUN CGO_ENABLED=0 go build -tags goolm -trimpath \
     -ldflags="-s -w" \
     -o /out/bridge ./cmd/bridge
 
+# Stage to fetch klazomenai/dotfiles-sourced skill content at a pinned SHA.
+# The bridge binary reads its skill content from the embedded fallback
+# (compiled into the binary via internal/crew/skills/embedded/); this
+# image-baked copy gives operators an inspectable surface
+# (`kubectl exec -- cat /var/lib/klazomenai/skills/_universal.md`) that
+# does not require grovelling the binary.
+#
+# DOTFILES_REF must be a full 40-char git SHA on klazomenai/dotfiles
+# main. Bump ceremony: see CONTRIBUTING.md "Bumping `DOTFILES_REF`".
+# The skills-drift CI workflow catches DOTFILES_REF bumps not paired
+# with a re-bundle of internal/crew/skills/embedded/.
+FROM alpine:3.21 AS dotfiles
+
+ARG DOTFILES_REF=4b856162d85d147648a26fb3fd5573a0f9b7e15d
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /dotfiles
+# Fetch by SHA directly; --depth=1 keeps the stage small. GitHub
+# permits arbitrary-SHA fetches on its hosted repos
+# (uploadpack.allowAnySHA1InWant), so no separate clone-then-checkout
+# round-trip is needed.
+RUN git init -q && \
+    git remote add origin https://github.com/Klazomenai/dotfiles && \
+    git fetch -q --depth=1 origin "${DOTFILES_REF}" && \
+    git checkout -q FETCH_HEAD
+
 # Alpine runtime — kubectl and helm needed for Maren/Bosun cluster tools.
 # Distroless has no package manager or shell; Alpine is minimal (~7MB) and
 # version-pinned per security skill guidance.
@@ -49,6 +76,20 @@ RUN install -d -m 0700 -o bridge -g bridge /var/lib/bridge && \
 
 COPY --from=builder /out/bridge /bridge
 COPY config/crew.yaml /config/crew.yaml
+
+# Bake skill content from the pinned dotfiles ref. The orchestrator
+# reads the embedded fallback (compiled into the binary) at runtime;
+# this image-baked copy is the operator-inspectable surface. The
+# skills-drift CI workflow catches drift between the embedded fallback
+# and the dotfiles ref these files come from.
+COPY --from=dotfiles /dotfiles/claude/profiles/_universal.md /var/lib/klazomenai/skills/_universal.md
+COPY --from=dotfiles /dotfiles/claude/skills/github/SKILL.md /var/lib/klazomenai/skills/github/SKILL.md
+COPY --from=dotfiles /dotfiles/claude/profiles/github.md /var/lib/klazomenai/skills/github/profile.md
+# `find ... -name '*.md'` recurses correctly into the github/ subdir;
+# the AC's `chmod -R 0444 .../*.md` form would only match the top-level
+# _universal.md because of shell-glob expansion semantics.
+RUN chown -R bridge:bridge /var/lib/klazomenai/skills && \
+    find /var/lib/klazomenai/skills -name '*.md' -exec chmod 0444 {} +
 
 USER bridge
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# Makefile for klazomenai/bridge. Operator helpers; the canonical build
+# path remains the `CGO_ENABLED=0 go build -tags goolm` invocation
+# documented in CONTRIBUTING.md.
+#
+# Run `make` (with no args) for a summary.
+
+.PHONY: help sync-skills
+
+.DEFAULT_GOAL := help
+
+# Sibling-checkout default; override with `make sync-skills DOTFILES_DIR=/path/to/dotfiles`.
+DOTFILES_DIR ?= ../dotfiles
+EMBEDDED_DIR := internal/crew/skills/embedded
+
+help: ## Show available targets
+	@awk 'BEGIN { FS = ":.*?## " } /^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+sync-skills: ## Re-bundle $(EMBEDDED_DIR)/ from a sibling dotfiles checkout
+	@test -d "$(DOTFILES_DIR)" || { \
+	  echo "error: DOTFILES_DIR ($(DOTFILES_DIR)) not found — clone klazomenai/dotfiles as a sibling or pass DOTFILES_DIR=/path/to/dotfiles"; \
+	  exit 1; \
+	}
+	@test -f "$(DOTFILES_DIR)/claude/profiles/_universal.md" || { \
+	  echo "error: $(DOTFILES_DIR) does not look like a klazomenai/dotfiles checkout (claude/profiles/_universal.md missing)"; \
+	  exit 1; \
+	}
+	@mkdir -p "$(EMBEDDED_DIR)/github"
+	@cp "$(DOTFILES_DIR)/claude/profiles/_universal.md"  "$(EMBEDDED_DIR)/_universal.md"
+	@cp "$(DOTFILES_DIR)/claude/skills/github/SKILL.md"  "$(EMBEDDED_DIR)/github/SKILL.md"
+	@cp "$(DOTFILES_DIR)/claude/profiles/github.md"      "$(EMBEDDED_DIR)/github/profile.md"
+	@echo "Synced $(EMBEDDED_DIR)/ from $(DOTFILES_DIR)."
+	@echo "After bumping DOTFILES_REF in Dockerfile, run 'make sync-skills' and commit"
+	@echo "both edits in one PR. The skills-drift CI workflow catches mismatches."

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DOTFILES_DIR ?= ../dotfiles
 EMBEDDED_DIR := internal/crew/skills/embedded
 
 help: ## Show available targets
-	@awk 'BEGIN { FS = ":.*?## " } /^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN { FS = ":.*## " } /^[a-zA-Z_-]+:.*## / { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 sync-skills: ## Re-bundle $(EMBEDDED_DIR)/ from a sibling dotfiles checkout
 	@test -d "$(DOTFILES_DIR)" || { \

--- a/TESTS.md
+++ b/TESTS.md
@@ -74,7 +74,9 @@ as callable, audit trails redact tokens.
 | `TestComposeMissingUniversalIsError` | `internal/crew/skills/compose_test.go` | Universal is mandatory when any skill is declared; missing → wrapped `ErrUniversalRequired` |
 | `TestComposeMissingSkillIsError` | `internal/crew/skills/compose_test.go` | Missing SKILL.md → wrapped `ErrNotFound` |
 | `TestFallbackSourceUsesEmbeddedWhenFilesystemMissing` | `internal/crew/skills/loader_test.go` | `FilesystemSource` ENOENT → `EmbeddedSource` content |
-| `TestEmbeddedSource{Universal,GitHubSkill,GitHubProfile}ContainsExpectedSentinel` | `internal/crew/skills/loader_test.go` | Each embedded blob carries a stable sentinel string |
+| `TestEmbeddedSourceUniversalContainsExpectedSentinel` | `internal/crew/skills/loader_test.go` | Embedded universal addendum carries a stable sentinel string |
+| `TestEmbeddedSourceGitHubSkillContainsExpectedSentinel` | `internal/crew/skills/loader_test.go` | Embedded github/SKILL.md carries a stable sentinel string |
+| `TestEmbeddedSourceGitHubProfileContainsExpectedSentinel` | `internal/crew/skills/loader_test.go` | Embedded github/profile.md carries a stable sentinel string |
 | `TestEmbeddedSourceContainsAllSkillsDeclaredInRealCrewYAML` | `internal/crew/registry_test.go` | Drift check: every `skills:` entry in `config/crew.yaml` has a resolvable blob in the embedded source |
 | `TestChipsPromptContainsUniversalRules` | `internal/crew/registry_test.go` | Sentinels: `Allowlist is fail-closed`, `Operator Intent Required`, `Refused outright`, `Pending-confirmation exception` present |
 | `TestChipsPromptContainsGitHubProfileRules` | `internal/crew/registry_test.go` | Sentinels: `must not be exposed as callable tools`, `NEVER autonomously resolve Copilot review threads`, `Refused outright` present |

--- a/TESTS.md
+++ b/TESTS.md
@@ -43,62 +43,48 @@ github profile addenda have all required H2 sections, and no SKILL.md
 references `_universal.md` (the asymmetric reference graph the redesign
 deliberately rejected).
 
-## L1 — Bridge unit tests
+## L1 — Bridge unit tests (migrated)
 
-Tests against today's vendored skill-content path (the `id == "chips"`
-gate in `internal/crew/registry.go`). These tests will migrate to
-`compose_test.go` once the Source/Compose loader rewrite (#148) lands.
+The pre-Compose vendored skill-content path is gone — the `id == "chips"`
+gate, the `//go:embed skills/github.md` directive, and the
+`chipsGitHubSkill` var all deleted in PR #161 (sub-issue **d** of #148).
+Tests migrated to the Compose path:
 
-Run:
+| Test | Status | Asserts |
+|------|--------|---------|
+| `TestChipsSystemPromptContainsGitHubSkill` | ✅ migrated | 10 load-bearing rule fragments survive Compose (`--gpg-sign`, `Refs #N`, `NEVER push to "main"`, etc.); boundary literal updated from the legacy `\n\n## Git + GitHub Workflow Rules` to Compose's emitted `\n\n## Github Workflow Rules\n` heading. Lives in `internal/crew/registry_test.go`. |
+| `TestNonChipsCrewLackGitHubSkill` | ✅ migrated | Same gating intent under the `skills: []` field in `crew.yaml`. Maren / Crest / Bosun / Lookout don't declare `skills:`, so Compose emits persona+verbosity only and the `Copilot Review Workflow` sentinel is absent from their SystemPrompt. |
 
-```sh
-CGO_ENABLED=0 go test -tags goolm ./internal/crew/...
-```
+## L2 — Composition + tool-loop enforcement (implemented)
 
-Covered today:
-
-| Test | What it covers | Migration target |
-|------|----------------|------------------|
-| `TestChipsSystemPromptContainsGitHubSkill` | 10 load-bearing rule fragments survive embedding (`--gpg-sign`, `Refs #N`, `NEVER push to main`, etc.) plus the `\n\n## Git + GitHub Workflow Rules` boundary marker. | `compose_test.go` after #148 — fragments stay; boundary literal updates to match `Compose`'s emitted heading. |
-| `TestNonChipsCrewLackGitHubSkill` | Embedding is gated to Chips — Maren / Crest / Bosun / Lookout must not see the github content. | Same gating intent under the new `skills: []` field in `crew.yaml`. |
-
-The test bodies carry `// TODO(#148):` comments flagging the migration
-intent so the assertions don't get accidentally deleted or re-written
-during the loader refactor.
-
-## L2 — Composition + tool-loop enforcement (pending #148)
-
-Tests the new Source/Compose plumbing AND the orchestrator's
-enforcement layer. **Pending Bridge #148** — these test files don't
-exist yet; the table below is the planned shape.
+The new Source/Compose plumbing AND the orchestrator's enforcement
+layer. **Implemented** across sub-issues **a–d** of #148 (PRs #156,
+#157+#158, #159+#160, #161, #165). All assertions run on every CI run.
 
 The architecture's value is in the *negative* tests: writes refuse
 non-allowlisted repos, mutations require operator intent in the most
 recent message, `gh pr merge` / `gh pr ready` aren't even registered
-as callable, audit trails redact tokens. L2 proves these claims fire.
+as callable, audit trails redact tokens.
 
-Planned files: `internal/crew/skills/compose_test.go`,
-`internal/crew/skills/loader_test.go` (matching the `loader.go` source
-file that hosts the `Source` interface + three implementations), plus
-extensions to `internal/crew/registry_test.go` and
-`internal/orchestrator/orchestrator_test.go`.
-
-| Planned test | Asserts |
-|--------------|---------|
-| `TestComposeOrderUniversalThenSkillThenProfile` | Composition order: universal → skill → profile, exact whitespace boundaries |
-| `TestComposeMissingProfileFallsThrough` | Skills without a profile addendum compose as universal+skill |
-| `TestComposeMissingUniversalIsError` | Universal is mandatory; missing → load-time error |
-| `TestFallbackSourceUsesEmbeddedWhenFilesystemMissing` | `FilesystemSource` ENOENT → `EmbeddedSource` content |
-| `TestEmbeddedSourceContainsAllSkillsListedInCrewYAML` | Drift check: `crew.yaml` `skills:` entries all have embedded blobs |
-| `TestChipsPromptContainsUniversalRules` | "fail-closed", "operator's most recent message", "audit record", "Refused outright" present |
-| `TestChipsPromptContainsGitHubProfileRules` | "must not be exposed as callable tools", "draft baked in", "NEVER autonomously resolve Copilot" present |
-| `TestChipsPromptDoesNotContainOperatorOnlyContent` | Operator-only sentinel absent from agent-consumed prompt |
-| `TestChipsRefusesNonAllowlistedRepo` | Mock Anthropic emits `tool_use` against non-allowlisted target → orchestrator allowlist gate fires before tool `Execute()` |
-| `TestChipsRefusesMutationWithoutOperatorIntent` | Mutation not in operator's most recent message → refusal |
-| `TestGhPrMergeNotRegistered` | `tools.Registry.Has("gh_pr_merge")` and `gh_pr_ready` return `false` |
-| `TestPendingConfirmationExceptionAccepts` | Two-turn: "close issue #99" → "confirm?" → "yes" → write proceeds |
-| `TestAuditRecordEmittedOnWrite` | Write tool invocation produces audit record on stderr / captured `io.Writer` |
-| `TestAuditRecordRedactsTokens` | Token-bearing argv → audit line shows `***REDACTED***` |
+| Test | File | Asserts |
+|------|------|---------|
+| `TestComposeOrderUniversalThenSkillThenProfile` | `internal/crew/skills/compose_test.go` | Composition order: persona → universal → skill → profile, exact whitespace boundaries |
+| `TestComposeBoundaryMarkers` | `internal/crew/skills/compose_test.go` | Each section is preceded by `\n\n## <Heading>\n\n` |
+| `TestComposeMissingProfileFallsThrough` | `internal/crew/skills/compose_test.go` | Skills without a profile addendum compose as persona+universal+skill |
+| `TestComposeMissingUniversalIsError` | `internal/crew/skills/compose_test.go` | Universal is mandatory when any skill is declared; missing → wrapped `ErrUniversalRequired` |
+| `TestComposeMissingSkillIsError` | `internal/crew/skills/compose_test.go` | Missing SKILL.md → wrapped `ErrNotFound` |
+| `TestFallbackSourceUsesEmbeddedWhenFilesystemMissing` | `internal/crew/skills/loader_test.go` | `FilesystemSource` ENOENT → `EmbeddedSource` content |
+| `TestEmbeddedSource{Universal,GitHubSkill,GitHubProfile}ContainsExpectedSentinel` | `internal/crew/skills/loader_test.go` | Each embedded blob carries a stable sentinel string |
+| `TestEmbeddedSourceContainsAllSkillsDeclaredInRealCrewYAML` | `internal/crew/registry_test.go` | Drift check: every `skills:` entry in `config/crew.yaml` has a resolvable blob in the embedded source |
+| `TestChipsPromptContainsUniversalRules` | `internal/crew/registry_test.go` | Sentinels: `Allowlist is fail-closed`, `Operator Intent Required`, `Refused outright`, `Pending-confirmation exception` present |
+| `TestChipsPromptContainsGitHubProfileRules` | `internal/crew/registry_test.go` | Sentinels: `must not be exposed as callable tools`, `NEVER autonomously resolve Copilot review threads`, `Refused outright` present |
+| `TestNonChipsCrewLackUniversal` | `internal/crew/registry_test.go` | The `## Operator Universal Rules` heading is absent from Maren / Crest / Bosun / Lookout SystemPrompts |
+| `TestChipsRefusesNonAllowlistedRepo` | `internal/orchestrator/orchestrator_test.go` | Mock Anthropic emits `tool_use` against non-allowlisted target → orchestrator wraps the tool's allowlist error as `is_error=true` tool_result before Claude sees it |
+| `TestChipsRefusesMutationWithoutOperatorIntent` | `internal/orchestrator/orchestrator_test.go` | Chips's SystemPrompt contains the Operator-Intent rule sentinel — the orchestrator sees the rule on every turn |
+| `TestPendingConfirmationExceptionAccepts` | `internal/orchestrator/orchestrator_test.go` | Two-turn: "close issue #99" → "confirm?" → "yes" → write proceeds, audit-log captures `"audit: tool invoked"` + `"mutation":true` |
+| `TestGhPrMergeNotRegistered` | `internal/tools/registry_test.go` | The production chips registry built via `chipstools.RegisterChipsTools` has `Has("gh_pr_merge") == false && Has("gh_pr_ready") == false`; the 7 expected chips tools ARE present |
+| `TestAuditRecordEmittedOnWrite` | `internal/tools/sandbox_test.go` | Mutation:true tool invocation emits structured audit record with the tool name, `mutation:true`, and `argv_redacted` field |
+| `TestAuditRecordRedactsTokens` | `internal/tools/sandbox_test.go` | Token-bearing argv → audit-log buffer contains `[REDACTED]`, not the raw token |
 
 L2's mock strategy: register a test-only mock tool via the existing
 `tools.Registry` interface. The allowlist gate, mutation-intent rule,


### PR DESCRIPTION
## Summary

Completes the #148 epic. Bakes klazomenai/dotfiles skill content into the image at a pinned SHA, adds a Makefile for re-bundling the embedded fallback during development, and wires up the drift CI workflow that fails when DOTFILES_REF bumps without a re-bundle. Documentation: TESTS.md L1+L2 sections now reflect actual code; CONTRIBUTING.md replaces the stale "Re-syncing the Chips skill body" section with the new "Bumping DOTFILES_REF" ceremony.

- **Dockerfile dotfiles stage** — new `FROM alpine:3.21 AS dotfiles` clones klazomenai/dotfiles at `ARG DOTFILES_REF=4b856162d85d147648a26fb3fd5573a0f9b7e15d` (current dotfiles main HEAD at time of authoring; embedded fallback already matches, so skills-drift CI passes on first run). Runtime stage COPYs three files into `/var/lib/klazomenai/skills/` with `chown -R bridge:bridge` + `find -name '*.md' -exec chmod 0444 {} +`.
- **Makefile** — first Makefile in this repo. Targets: `help` (default; lists available targets) and `sync-skills` (re-bundles `internal/crew/skills/embedded/` from a sibling klazomenai/dotfiles checkout; defaults to `../dotfiles/`, override via `DOTFILES_DIR=...`). The canonical build path remains `CGO_ENABLED=0 go build -tags goolm` documented in CONTRIBUTING.md.
- **skills-drift workflow** — new `.github/workflows/skills-drift.yml`. Triggers: `pull_request` paths-filter on `internal/crew/skills/embedded/**` + `Dockerfile`; weekly cron Monday 09:00 UTC. Extracts `DOTFILES_REF` from Dockerfile (rejects non-SHA refs), clones dotfiles at that SHA, diffs each embedded file against its dotfiles source, fails with unified-diff annotations on any mismatch. Resolution message tells the operator the two exits (re-bundle vs. revert).
- **Documentation cascade** — TESTS.md L1 section reframed as "migrated"; L2 placeholder table replaced with the 17 implemented tests and their file locations. CONTRIBUTING.md's "Re-syncing the Chips skill body" section (now stale — the vendored file it documented is deleted) replaced with "Bumping DOTFILES_REF" ceremony documenting the four-step bump.

After this PR merges the loader rewrite is complete and embedded-vs-image-vs-dotfiles drift is caught in CI.

## Test plan

- [ ] `go vet -tags goolm ./...` clean
- [ ] `go test -tags goolm ./internal/...` all 14 packages green
- [ ] `shellcheck .github/scripts/*.sh` clean
- [ ] `make sync-skills` against the existing dotfiles main HEAD is idempotent (no diff against embedded/)
- [ ] `docker build .` succeeds via CI's docker job (no local docker on the author's machine)
- [ ] `lint-workflows.yml` (the actionlint job that landed in PR #164) passes against the new `skills-drift.yml`
- [ ] `skills-drift.yml` itself runs on this PR (the path-filter matches `Dockerfile`); first run should pass since embedded/ matches `DOTFILES_REF=4b856162d85d147648a26fb3fd5573a0f9b7e15d`
- [ ] **Optional follow-up smoke test** (deferred to a scratch PR after merge): mutate `internal/crew/skills/embedded/_universal.md` in a draft PR → drift CI fails with diff output; revert → drift CI passes
- [ ] **Optional follow-up smoke test** (deferred to a scratch PR after merge): bump `DOTFILES_REF` without re-bundling → drift CI fails

## Notes

- AC text says "Pinned actions to SHA (per repo convention)" but the actual repo convention across `ci.yml`, `release-please.yml`, and `lint-workflows.yml` is **tag pins** (`@v4`, `@v5`, etc.). New workflow follows the existing repo convention; introducing SHA pinning just on this one workflow would be inconsistent. Filing the broader move-all-workflows-to-SHA-pinning as a separate consideration if the operator wants supply-chain hardening widened.
- AC text says `chmod -R 0444 /var/lib/klazomenai/skills/*.md` — that form's shell glob expansion only matches top-level `_universal.md` and would leave `github/SKILL.md` + `github/profile.md` at COPY default (0644). The Dockerfile uses `find -name '*.md' -exec chmod 0444 {} +` to apply the spirit of the AC to all three files. Inline comment notes the deviation.
- AC describes one `TestChipsPromptDoesNotContainOperatorOnlyContent` test in the original L2 table — this relied on an operator-only-stripping feature in profile.md that was never built and isn't currently scoped. The new TESTS.md L2 table omits it (consistent with the implementation surface).

Refs #148
Refs #155
