### PR TITLE
docs(contrib): introduce crew:* label namespace 📝

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,11 @@ Where the rigging is dressed, every line in its place:
 - Domain: `domain:infra`, `domain:ai`, `domain:android`, `domain:matrix`,
   `domain:security`
 - Priority: `priority:high`, `priority:medium`, `priority:low`
+- Crew: `crew:chips`, `crew:maren`, `crew:crest`, `crew:bosun`,
+  `crew:lookout`. Apply when a specific crew member is the primary
+  subject of the issue or PR. Cross-cutting work (orchestrator, loader,
+  observability surfaces, build/CI) stays untagged — the label is for
+  per-persona signal, not for surfaces that touch every persona equally.
 - Override: `allow-coverage-drop` — applied to a PR that intentionally
   drops per-package test coverage (e.g. removing a tested code path
   during a refactor). The gate still runs and posts the coverage delta


### PR DESCRIPTION
## Summary

Doc-only PR that introduces a new `crew:*` label namespace in `CONTRIBUTING.md`'s Labels section. Five labels (`crew:chips`, `crew:maren`, `crew:crest`, `crew:bosun`, `crew:lookout`) for the five named crew members. Apply when a specific crew member is the primary subject; cross-cutting work (orchestrator, loader, observability, build/CI) stays untagged.

Why: a recent per-crew issue inventory missed `CHIPS_REPO_ALLOWLIST` because title-keyword filters don't catch case variants and don't surface cross-cutting work where one crew is the primary subject. Label-based filtering is exact, case-stable, and supports the `gh issue list --label crew:chips` workflow.

## Test plan

This PR is the doc half of #168. The full AC includes out-of-band label creation + backfill, which happen after this PR merges:

- [ ] CI green (test + license-audit + docker + lint-workflows + skills-drift + actionlint + shellcheck)
- [ ] `CONTRIBUTING.md` Labels section has the new `crew:*` bullet between `priority:*` and `allow-coverage-drop` (consistent positioning with the existing namespace-style bullets)
- [ ] The convention statement reads as the source of truth for when to apply the labels and when to leave issues untagged

**Post-merge** (tracked under #168's AC):

- [ ] `gh label create` for the 5 labels (with the colours + descriptions specified in #168's body)
- [ ] Backfill apply: #57 / #58 / #140 / #141 / #142 / #167 get `crew:chips`; #81 gets `crew:crest`; #41 gets `crew:bosun`; #128 gets `crew:lookout`
- [ ] #168 closed with verification table

Refs #168
