### PR TITLE
security(chips): pattern-based sanitiser for tool output 🔐

### DIFF
--- a/internal/tools/chips/chips_test.go
+++ b/internal/tools/chips/chips_test.go
@@ -61,7 +61,7 @@ func TestParseRepoAllowlistEmpty(t *testing.T) {
 
 func TestSanitiseOutputStripsToken(t *testing.T) {
 	output := "some output with ghp_abc123secret in it"
-	result := chips.SanitiseOutputForTest(output, "ghp_abc123secret")
+	result := chips.SanitiseOutputForTest(output, "ghp_abc123secret", "")
 	if strings.Contains(result, "ghp_abc123secret") {
 		t.Error("output still contains token")
 	}
@@ -72,7 +72,7 @@ func TestSanitiseOutputStripsToken(t *testing.T) {
 
 func TestSanitiseOutputEmptyToken(t *testing.T) {
 	output := "safe output"
-	result := chips.SanitiseOutputForTest(output, "")
+	result := chips.SanitiseOutputForTest(output, "", "")
 	if result != output {
 		t.Errorf("expected unchanged output, got %q", result)
 	}

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -4,6 +4,7 @@ package chips
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
 
@@ -64,6 +65,19 @@ var SanitiseOutputForTest = sanitiseOutput
 // The order is deliberate: known-secret substring replacement is
 // cheap and always-correct, so it runs first; pattern-based
 // detection is a regex pass under a length cap and runs second.
-func sanitiseOutput(output, token string) string {
-	return Sanitise(redact.Redact(output, token))
+//
+// When tool is non-empty, every pattern match in step 2 emits one
+// slog.Info "sanitiser_redaction" line tagged with `tool` (the
+// caller's Tool.Name(), e.g. "gh_issue_view") and `field=output`.
+// Tests pass tool="" to stay silent; production callers pass
+// t.Name().
+func sanitiseOutput(output, token, tool string) string {
+	cleaned := redact.Redact(output, token)
+	if tool == "" {
+		return Sanitise(cleaned)
+	}
+	return Sanitise(cleaned,
+		slog.String("tool", tool),
+		slog.String("field", "output"),
+	)
 }

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -54,9 +54,10 @@ var SanitiseOutputForTest = sanitiseOutput
 //
 //  1. redact.Redact strips the known GITHUB_TOKEN value (substring
 //     replacement, callers supply the exact secret).
-//  2. Sanitise (this package) applies the shared redact.Patterns
-//     plus any chips-specific extras to catch token-shaped strings
-//     in untrusted comment / issue / PR bodies the operator never
+//  2. Sanitise (this package) applies the redact package default
+//     pattern set (obtained via redact.DefaultPatterns) plus any
+//     chips-specific extras to catch token-shaped strings in
+//     untrusted comment / issue / PR bodies the operator never
 //     supplied as a known secret (e.g. an AWS key pasted into a
 //     GitHub comment by a third party).
 //

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -71,6 +71,20 @@ var SanitiseOutputForTest = sanitiseOutput
 // caller's Tool.Name(), e.g. "gh_issue_view") and `field=output`.
 // Tests pass tool="" to stay silent; production callers pass
 // t.Name().
+//
+// Scope deviation from #83 AC body: the spec body says "Touch only
+// the *content* fields (issue.body, comment.body, review.body),
+// never structural fields (numbers, URLs, dates)." This function
+// runs the chain over the WHOLE `gh --json` stdout rather than
+// unmarshalling and walking specific content-field paths. The
+// patterns are narrow enough that numbers, dates, and non-token-
+// bearing URLs aren't matched in practice; in the one edge case
+// where the deviation matters (a URL query string containing
+// `?password=...`), the result is desirable redaction of a
+// secret-in-URL leak. Per-field walking was deemed unnecessary
+// complexity given the orchestrator-level safety floor in #129
+// will apply the same patterns whole-output downstream anyway.
+// Pinned in the #83 close-out discussion.
 func sanitiseOutput(output, token, tool string) string {
 	cleaned := redact.Redact(output, token)
 	if tool == "" {

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -49,10 +49,20 @@ func (a RepoAllowlist) Check(org, repo string) error {
 // SanitiseOutputForTest is an exported alias for testing.
 var SanitiseOutputForTest = sanitiseOutput
 
-// sanitiseOutput strips the GITHUB_TOKEN value from output if present.
-// Thin wrapper over redact.Redact so existing chips call sites keep
-// their two-argument shape; the package-level redactor is shared with
-// the audit-log path (sandbox.go).
+// sanitiseOutput chains two redaction primitives on every gh_* /
+// git_* tool output:
+//
+//  1. redact.Redact strips the known GITHUB_TOKEN value (substring
+//     replacement, callers supply the exact secret).
+//  2. Sanitise (this package) applies the shared redact.Patterns
+//     plus any chips-specific extras to catch token-shaped strings
+//     in untrusted comment / issue / PR bodies the operator never
+//     supplied as a known secret (e.g. an AWS key pasted into a
+//     GitHub comment by a third party).
+//
+// The order is deliberate: known-secret substring replacement is
+// cheap and always-correct, so it runs first; pattern-based
+// detection is a regex pass under a length cap and runs second.
 func sanitiseOutput(output, token string) string {
-	return redact.Redact(output, token)
+	return Sanitise(redact.Redact(output, token))
 }

--- a/internal/tools/chips/gh_issue_list.go
+++ b/internal/tools/chips/gh_issue_list.go
@@ -70,5 +70,5 @@ func (t *GHIssueListTool) Execute(ctx context.Context, input json.RawMessage) (s
 	if err != nil {
 		return "", fmt.Errorf("gh issue list: %w", err)
 	}
-	return sanitiseOutput(string(out), t.token), nil
+	return sanitiseOutput(string(out), t.token, t.Name()), nil
 }

--- a/internal/tools/chips/gh_issue_view.go
+++ b/internal/tools/chips/gh_issue_view.go
@@ -60,5 +60,5 @@ func (t *GHIssueViewTool) Execute(ctx context.Context, input json.RawMessage) (s
 	if err != nil {
 		return "", fmt.Errorf("gh issue view: %w", err)
 	}
-	return sanitiseOutput(string(out), t.token), nil
+	return sanitiseOutput(string(out), t.token, t.Name()), nil
 }

--- a/internal/tools/chips/gh_pr_checks.go
+++ b/internal/tools/chips/gh_pr_checks.go
@@ -60,5 +60,5 @@ func (t *GHPRChecksTool) Execute(ctx context.Context, input json.RawMessage) (st
 	if err != nil {
 		return "", fmt.Errorf("gh pr checks: %w", err)
 	}
-	return sanitiseOutput(string(out), t.token), nil
+	return sanitiseOutput(string(out), t.token, t.Name()), nil
 }

--- a/internal/tools/chips/gh_pr_list.go
+++ b/internal/tools/chips/gh_pr_list.go
@@ -70,5 +70,5 @@ func (t *GHPRListTool) Execute(ctx context.Context, input json.RawMessage) (stri
 	if err != nil {
 		return "", fmt.Errorf("gh pr list: %w", err)
 	}
-	return sanitiseOutput(string(out), t.token), nil
+	return sanitiseOutput(string(out), t.token, t.Name()), nil
 }

--- a/internal/tools/chips/gh_pr_view.go
+++ b/internal/tools/chips/gh_pr_view.go
@@ -60,5 +60,5 @@ func (t *GHPRViewTool) Execute(ctx context.Context, input json.RawMessage) (stri
 	if err != nil {
 		return "", fmt.Errorf("gh pr view: %w", err)
 	}
-	return sanitiseOutput(string(out), t.token), nil
+	return sanitiseOutput(string(out), t.token, t.Name()), nil
 }

--- a/internal/tools/chips/git_diff.go
+++ b/internal/tools/chips/git_diff.go
@@ -66,5 +66,5 @@ func (t *GitDiffTool) Execute(ctx context.Context, input json.RawMessage) (strin
 	if err != nil {
 		return "", fmt.Errorf("git diff: %w", err)
 	}
-	return sanitiseOutput(string(out), t.token), nil
+	return sanitiseOutput(string(out), t.token, t.Name()), nil
 }

--- a/internal/tools/chips/git_log.go
+++ b/internal/tools/chips/git_log.go
@@ -72,5 +72,5 @@ func (t *GitLogTool) Execute(ctx context.Context, input json.RawMessage) (string
 	if err != nil {
 		return "", fmt.Errorf("git log: %w", err)
 	}
-	return sanitiseOutput(string(out), t.token), nil
+	return sanitiseOutput(string(out), t.token, t.Name()), nil
 }

--- a/internal/tools/chips/sanitise.go
+++ b/internal/tools/chips/sanitise.go
@@ -1,6 +1,10 @@
 package chips
 
-import "klazomenai/bridge/internal/tools/redact"
+import (
+	"log/slog"
+
+	"klazomenai/bridge/internal/tools/redact"
+)
 
 // chipsPatterns holds Chips-specific Sanitiser rules that supplement
 // the shared redact default pattern set (obtained via
@@ -26,11 +30,16 @@ func allChipsPatterns() []redact.Pattern {
 // additions to input. Fail-closed: any internal panic returns
 // redact.SanitiserErrorReplacement (see redact.SanitiseWith).
 //
+// Optional logAttrs are passed through to redact.SanitiseWith and
+// emit one slog.Info line per matched pattern (with pattern_name +
+// count). Callers in the gh_* / git_* tool layer (see sanitiseOutput
+// in exec.go) pass `tool` and `field` attrs; tests and the
+// orchestrator-level safety floor in #129 pass none and stay silent.
+//
 // This is the per-tool first line of defence applied at every gh_*
-// tool's output boundary (see sanitiseOutput in exec.go). The
-// orchestrator-level safety floor (issue #129) applies the same
-// shared patterns again to every tool_result regardless of which
-// tool produced it.
-func Sanitise(input string) string {
-	return redact.SanitiseWith(input, allChipsPatterns())
+// tool's output boundary. The orchestrator-level safety floor (issue
+// #129) applies the same shared patterns again to every tool_result
+// regardless of which tool produced it.
+func Sanitise(input string, logAttrs ...slog.Attr) string {
+	return redact.SanitiseWith(input, allChipsPatterns(), logAttrs...)
 }

--- a/internal/tools/chips/sanitise.go
+++ b/internal/tools/chips/sanitise.go
@@ -1,0 +1,36 @@
+package chips
+
+import "klazomenai/bridge/internal/tools/redact"
+
+// chipsPatterns holds Chips-specific Sanitiser rules that supplement
+// the shared redact.Patterns set. Empty today — the shared set covers
+// Chips' threat model (untrusted GitHub comment / issue / PR bodies
+// containing token-shaped strings). Reserved as an extension point
+// if a GitHub-specific shape arises that should NOT apply to other
+// crew (e.g. GitHub repo deploy keys with a shape distinct from any
+// other secret).
+var chipsPatterns = []redact.Pattern{}
+
+// allChipsPatterns returns the combined Sanitiser pattern set used by
+// Sanitise: the shared redact.Patterns followed by chipsPatterns.
+// Constructed per-call so that tests reordering or shadowing the
+// underlying slices do not produce stale composite state.
+func allChipsPatterns() []redact.Pattern {
+	out := make([]redact.Pattern, 0, len(redact.Patterns)+len(chipsPatterns))
+	out = append(out, redact.Patterns...)
+	out = append(out, chipsPatterns...)
+	return out
+}
+
+// Sanitise applies the shared redact patterns plus any Chips-specific
+// additions to input. Fail-closed: any internal panic returns
+// redact.SanitiserErrorReplacement (see redact.SanitiseWith).
+//
+// This is the per-tool first line of defence applied at every gh_*
+// tool's output boundary (see sanitiseOutput in exec.go). The
+// orchestrator-level safety floor (issue #129) applies the same
+// shared patterns again to every tool_result regardless of which
+// tool produced it.
+func Sanitise(input string) string {
+	return redact.SanitiseWith(input, allChipsPatterns())
+}

--- a/internal/tools/chips/sanitise.go
+++ b/internal/tools/chips/sanitise.go
@@ -3,12 +3,13 @@ package chips
 import "klazomenai/bridge/internal/tools/redact"
 
 // chipsPatterns holds Chips-specific Sanitiser rules that supplement
-// the shared redact.Patterns set. Empty today — the shared set covers
-// Chips' threat model (untrusted GitHub comment / issue / PR bodies
-// containing token-shaped strings). Reserved as an extension point
-// if a GitHub-specific shape arises that should NOT apply to other
-// crew (e.g. GitHub repo deploy keys with a shape distinct from any
-// other secret).
+// the shared redact default pattern set (obtained via
+// redact.DefaultPatterns at composition time). Empty today — the
+// shared set covers Chips' threat model (untrusted GitHub comment /
+// issue / PR bodies containing token-shaped strings). Reserved as an
+// extension point if a GitHub-specific shape arises that should NOT
+// apply to other crew (e.g. GitHub repo deploy keys with a shape
+// distinct from any other secret).
 var chipsPatterns = []redact.Pattern{}
 
 // allChipsPatterns returns the combined Sanitiser pattern set used by

--- a/internal/tools/chips/sanitise.go
+++ b/internal/tools/chips/sanitise.go
@@ -12,14 +12,13 @@ import "klazomenai/bridge/internal/tools/redact"
 var chipsPatterns = []redact.Pattern{}
 
 // allChipsPatterns returns the combined Sanitiser pattern set used by
-// Sanitise: the shared redact.Patterns followed by chipsPatterns.
-// Constructed per-call so that tests reordering or shadowing the
-// underlying slices do not produce stale composite state.
+// Sanitise: the shared redact default patterns followed by
+// chipsPatterns. Constructed per-call via redact.DefaultPatterns so
+// chips cannot accidentally mutate the package default set, and so
+// tests reordering or shadowing the underlying slices do not produce
+// stale composite state.
 func allChipsPatterns() []redact.Pattern {
-	out := make([]redact.Pattern, 0, len(redact.Patterns)+len(chipsPatterns))
-	out = append(out, redact.Patterns...)
-	out = append(out, chipsPatterns...)
-	return out
+	return append(redact.DefaultPatterns(), chipsPatterns...)
 }
 
 // Sanitise applies the shared redact patterns plus any Chips-specific

--- a/internal/tools/chips/sanitise_test.go
+++ b/internal/tools/chips/sanitise_test.go
@@ -119,8 +119,14 @@ func TestChipsSanitiseRespectsSharedMaxBytes(t *testing.T) {
 func TestSanitiseOutputChainKnownTokenStillRedacted(t *testing.T) {
 	// Regression assertion for the original #152 contract: when a
 	// known GITHUB_TOKEN value is supplied, it is substring-redacted
-	// to the [REDACTED] sentinel regardless of pattern shape.
-	token := "ghp_thisIsNotAValidPatternMatchTokenButCallerKnowsIt"
+	// to the [REDACTED] sentinel by redact.Redact's first pass, even
+	// when the value's shape does not match any default Sanitise
+	// pattern. The token below contains `-` characters inside the
+	// `ghp_` body, which falls outside the github_token pattern's
+	// `[A-Za-z0-9]{36,}` character class — so the substring path is
+	// the only mechanism that can catch it. Asserts the chain's
+	// first stage in isolation.
+	token := "ghp_known-test-secret-with-dashes-only-substring-catches-it"
 	out := chips.SanitiseOutputForTest("emit "+token+" and stop", token)
 	if strings.Contains(out, token) {
 		t.Errorf("known token surfaced: %q", out)

--- a/internal/tools/chips/sanitise_test.go
+++ b/internal/tools/chips/sanitise_test.go
@@ -25,7 +25,7 @@ func TestChipsSanitisePerPatternPositive(t *testing.T) {
 		{"github_token_ghu", "leaked user token ghu_" + strings.Repeat("B", 40) + " end", "ghu_…REDACTED"},
 		{"github_pat", "found token github_pat_" + strings.Repeat("C", 30) + " in logs", "github_pat_…REDACTED"},
 		{"openai_anthropic_key", "claude key sk-ant-" + strings.Repeat("d", 40) + " in comment", "sk-…REDACTED"},
-		{"slack_token", "slack bot tok xoxb-1234567890-abcde-fghijk in body", "xox-…REDACTED"},
+		{"slack_token", "slack bot tok xoxb-1234567890-abcde-fghijk in body", "xoxb-…REDACTED"},
 		{"jwt", "auth=eyJ-TEST-HEADER-PART.eyJ-TEST-PAYLOAD-PART.TEST-SIGNATURE-PART rest", "JWT-REDACTED"},
 		{"pem_block", "found:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAA\nKCAQEA\n-----END RSA PRIVATE KEY-----\nin comment", "-----BEGIN … KEY----- REDACTED -----END … KEY-----"},
 		{"bearer_token", "Authorization: Bearer abc123def456ghi.789-jkl_mno", "Bearer REDACTED"},

--- a/internal/tools/chips/sanitise_test.go
+++ b/internal/tools/chips/sanitise_test.go
@@ -135,7 +135,12 @@ func TestChipsSanitiseIdempotence(t *testing.T) {
 		"plain pr title",
 		"comment with AKIATESTKEY012345678 planted",
 		"long body ghp_" + strings.Repeat("A", 40) + " somewhere",
-		"Authorization: Bearer xyz-123",
+		// Bearer fixture matches the `{16,}` minimum so idempotence
+		// is actually exercised at the chips boundary; the earlier
+		// `Bearer xyz-123` shape was sub-cap and didn't trigger the
+		// pattern, making the double-pass assertion vacuous.
+		"Authorization: Bearer abc-123def-456-789-token-here",
+		"slack hook xoxb-1234567890-abcde-fghij in body",
 		"in env: DATABASE_PASSWORD=hunter2",
 	}
 	for _, in := range inputs {
@@ -241,18 +246,29 @@ func TestSanitiseOutputChainBothPathsTogether(t *testing.T) {
 	}
 }
 
+// captureSlogForChips installs a buffer-backed slog.Logger via
+// redact.SetLogger and returns the buffer plus a restore function.
+// Routing via redact.SetLogger keeps tests off slog.Default and
+// avoids any global-state hazard if future test runs adopt
+// t.Parallel() in this package.
+func captureSlogForChips(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	restore := redact.SetLogger(logger)
+	return &buf, restore
+}
+
 func TestSanitiseOutputThreadsToolNameToLogWhenSet(t *testing.T) {
 	// AC10 (#83): production callers in gh_*.go / git_*.go pass
 	// t.Name() as the third arg to sanitiseOutput. The log line for
 	// each pattern match must carry that tool name in the `tool`
 	// attribute (operators trace per-tool redaction frequency from
 	// Loki without needing to correlate via timestamps).
-	var buf bytes.Buffer
-	original := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	})))
-	defer slog.SetDefault(original)
+	buf, restore := captureSlogForChips(t)
+	defer restore()
 
 	planted := "AKIA" + strings.Repeat("Q", 16)
 	_ = chips.SanitiseOutputForTest("leaked "+planted+" here", "", "gh_issue_view")
@@ -274,12 +290,8 @@ func TestSanitiseOutputSilentWhenToolNameEmpty(t *testing.T) {
 	// runs but no slog line is emitted. Pins that tests don't
 	// pollute production log output AND that empty tool string is
 	// a safe no-log signal (not a tool literally named "").
-	var buf bytes.Buffer
-	original := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	})))
-	defer slog.SetDefault(original)
+	buf, restore := captureSlogForChips(t)
+	defer restore()
 
 	planted := "AKIA" + strings.Repeat("Q", 16)
 	out := chips.SanitiseOutputForTest("leaked "+planted+" here", "", "")

--- a/internal/tools/chips/sanitise_test.go
+++ b/internal/tools/chips/sanitise_test.go
@@ -1,6 +1,8 @@
 package chips_test
 
 import (
+	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -193,7 +195,7 @@ func TestSanitiseOutputChainKnownTokenStillRedacted(t *testing.T) {
 	// the only mechanism that can catch it. Asserts the chain's
 	// first stage in isolation.
 	token := "ghp_known-test-secret-with-dashes-only-substring-catches-it"
-	out := chips.SanitiseOutputForTest("emit "+token+" and stop", token)
+	out := chips.SanitiseOutputForTest("emit "+token+" and stop", token, "")
 	if strings.Contains(out, token) {
 		t.Errorf("known token surfaced: %q", out)
 	}
@@ -208,7 +210,7 @@ func TestSanitiseOutputChainPlantedTokenPatternRedacted(t *testing.T) {
 	// GitHub comment body) gets caught by pattern matching even though
 	// the caller passes an empty / different token.
 	planted := "AKIA" + strings.Repeat("Q", 16)
-	out := chips.SanitiseOutputForTest("attacker planted: "+planted+" here", "")
+	out := chips.SanitiseOutputForTest("attacker planted: "+planted+" here", "", "")
 	if strings.Contains(out, planted) {
 		t.Errorf("planted token surfaced: %q", out)
 	}
@@ -224,7 +226,7 @@ func TestSanitiseOutputChainBothPathsTogether(t *testing.T) {
 	token := "ghp_realOperatorTokenValueKnownLiterally"
 	planted := "AKIA" + strings.Repeat("J", 16)
 	in := "tool error: " + token + "\nissue body: " + planted + "\n"
-	out := chips.SanitiseOutputForTest(in, token)
+	out := chips.SanitiseOutputForTest(in, token, "")
 	if strings.Contains(out, token) {
 		t.Errorf("known token surfaced: %q", out)
 	}
@@ -239,12 +241,67 @@ func TestSanitiseOutputChainBothPathsTogether(t *testing.T) {
 	}
 }
 
+func TestSanitiseOutputThreadsToolNameToLogWhenSet(t *testing.T) {
+	// AC10 (#83): production callers in gh_*.go / git_*.go pass
+	// t.Name() as the third arg to sanitiseOutput. The log line for
+	// each pattern match must carry that tool name in the `tool`
+	// attribute (operators trace per-tool redaction frequency from
+	// Loki without needing to correlate via timestamps).
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+	defer slog.SetDefault(original)
+
+	planted := "AKIA" + strings.Repeat("Q", 16)
+	_ = chips.SanitiseOutputForTest("leaked "+planted+" here", "", "gh_issue_view")
+
+	logOut := buf.String()
+	if !strings.Contains(logOut, `"tool":"gh_issue_view"`) {
+		t.Errorf("expected tool=gh_issue_view in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"field":"output"`) {
+		t.Errorf("expected field=output in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"pattern_name":"aws_access_key"`) {
+		t.Errorf("expected pattern_name=aws_access_key in log, got: %s", logOut)
+	}
+}
+
+func TestSanitiseOutputSilentWhenToolNameEmpty(t *testing.T) {
+	// Test/SanitiseOutputForTest callers pass tool="" — sanitisation
+	// runs but no slog line is emitted. Pins that tests don't
+	// pollute production log output AND that empty tool string is
+	// a safe no-log signal (not a tool literally named "").
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+	defer slog.SetDefault(original)
+
+	planted := "AKIA" + strings.Repeat("Q", 16)
+	out := chips.SanitiseOutputForTest("leaked "+planted+" here", "", "")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected silent sanitisation with empty tool, got log: %s",
+			buf.String())
+	}
+	// Sanity check: redaction still happened (the absence of the
+	// raw planted token in `out` proves the silent path still
+	// applies the patterns).
+	if strings.Contains(out, planted) {
+		t.Errorf("silent path did not sanitise: %q", out)
+	}
+}
+
 func TestSanitiseOutputChainEmptyTokenStillSanitisesPatterns(t *testing.T) {
 	// Pre-#83 behaviour: empty token meant no substring redaction
 	// happened. Post-#83: pattern-based Sanitise still runs even when
 	// the caller has no known secret to redact.
 	in := "comment: ghp_" + strings.Repeat("M", 40) + " end"
-	out := chips.SanitiseOutputForTest(in, "")
+	out := chips.SanitiseOutputForTest(in, "", "")
 	if !strings.Contains(out, "ghp_…REDACTED") {
 		t.Errorf("expected pattern sentinel with empty token: %q", out)
 	}

--- a/internal/tools/chips/sanitise_test.go
+++ b/internal/tools/chips/sanitise_test.go
@@ -1,0 +1,179 @@
+package chips_test
+
+import (
+	"strings"
+	"testing"
+
+	"klazomenai/bridge/internal/tools/chips"
+	"klazomenai/bridge/internal/tools/redact"
+)
+
+// TestChipsSanitisePerPatternPositive pins that chips.Sanitise — not
+// just the underlying redact.Sanitise — applies every named pattern.
+// Per-pattern negative cases live in internal/tools/redact/redact_test.go
+// alongside the pattern definitions; this table is the chips-side
+// delegation contract demanded by #83's AC: "Unit tests in
+// internal/tools/chips/sanitise_test.go cover each pattern".
+func TestChipsSanitisePerPatternPositive(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		mustContain string
+	}{
+		{"aws_access_key", "comment body: AKIATESTKEY012345678 planted by attacker", "AKIA…REDACTED"},
+		{"github_token_ghp", "Hey check out this PAT: ghp_" + strings.Repeat("Z", 40) + " — please rotate", "ghp_…REDACTED"},
+		{"github_token_ghu", "leaked user token ghu_" + strings.Repeat("B", 40) + " end", "ghu_…REDACTED"},
+		{"github_pat", "found token github_pat_" + strings.Repeat("C", 30) + " in logs", "github_pat_…REDACTED"},
+		{"openai_anthropic_key", "claude key sk-ant-" + strings.Repeat("d", 40) + " in comment", "sk-…REDACTED"},
+		{"slack_token", "slack bot tok xoxb-1234567890-abcde-fghijk in body", "xox-…REDACTED"},
+		{"jwt", "auth=eyJ-TEST-HEADER-PART.eyJ-TEST-PAYLOAD-PART.TEST-SIGNATURE-PART rest", "JWT-REDACTED"},
+		{"pem_block", "found:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAA\nKCAQEA\n-----END RSA PRIVATE KEY-----\nin comment", "-----BEGIN … KEY----- REDACTED -----END … KEY-----"},
+		{"bearer_token", "Authorization: Bearer abc123def456ghi.789-jkl_mno", "Bearer REDACTED"},
+		{"password_assignment", "config snippet password: hunter2-but-longer", "password: REDACTED"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := chips.Sanitise(tc.input)
+			if !strings.Contains(out, tc.mustContain) {
+				t.Errorf("expected %q in output, got: %q", tc.mustContain, out)
+			}
+		})
+	}
+}
+
+func TestChipsSanitisePreservesInnocentText(t *testing.T) {
+	// Real PR titles and bodies must pass through unchanged.
+	// "Bearer" without a token, "password" as a noun, AKIA-shorter
+	// strings, etc. all stay intact.
+	inputs := []string{
+		"feat(crew): add a delegate path",
+		"This PR fixes the bearer of bad news pattern",
+		"My passwordless flow needs more docs",
+		"The AKIA prefix is short for AWS Key Identity ABC",
+		"Discussion of sk- prefixed identifiers in research",
+	}
+	for _, in := range inputs {
+		t.Run(in[:min(len(in), 40)], func(t *testing.T) {
+			out := chips.Sanitise(in)
+			if out != in {
+				t.Errorf("benign text altered: %q → %q", in, out)
+			}
+		})
+	}
+}
+
+func TestChipsSanitiseIdempotence(t *testing.T) {
+	// Chips Sanitise idempotence is load-bearing for #129's
+	// orchestrator-level safety floor: the floor applies the same
+	// pattern set, so a Chips-already-Sanitised output must not be
+	// disturbed when it lands at the floor.
+	inputs := []string{
+		"plain pr title",
+		"comment with AKIATESTKEY012345678 planted",
+		"long body ghp_" + strings.Repeat("A", 40) + " somewhere",
+		"Authorization: Bearer xyz-123",
+		"in env: DATABASE_PASSWORD=hunter2",
+	}
+	for _, in := range inputs {
+		t.Run(in[:min(len(in), 40)], func(t *testing.T) {
+			once := chips.Sanitise(in)
+			twice := chips.Sanitise(once)
+			if once != twice {
+				t.Errorf("chips.Sanitise not idempotent:\n  once:  %q\n  twice: %q", once, twice)
+			}
+		})
+	}
+}
+
+func TestChipsSanitiseFailClosedSurfaceMatchesRedact(t *testing.T) {
+	// Chips Sanitise delegates to redact.SanitiseWith, so the
+	// fail-closed contract is inherited. Verifying empty input is
+	// the smoke test that the wrapper does not introduce its own
+	// failure surface ahead of redact's recover.
+	if out := chips.Sanitise(""); out != "" {
+		t.Errorf("empty input altered: %q", out)
+	}
+}
+
+func TestChipsSanitiseRespectsSharedMaxBytes(t *testing.T) {
+	// chips.Sanitise inherits redact.MaxSanitiserInputBytes via
+	// redact.SanitiseWith. A token planted past the cap must be
+	// truncated away, not surfaced or processed.
+	tail := "AKIATESTKEY012345678"
+	in := strings.Repeat("x", redact.MaxSanitiserInputBytes) + " " + tail
+	out := chips.Sanitise(in)
+	if strings.Contains(out, tail) {
+		t.Error("tail token surfaced past truncation in chips wrapper")
+	}
+	if len(out) > redact.MaxSanitiserInputBytes {
+		t.Errorf("chips output exceeds shared cap: %d bytes", len(out))
+	}
+}
+
+// SanitiseOutput (the exec.go wrapper called by every gh_* tool) must
+// chain redact.Redact (substring) and chips.Sanitise (pattern). The
+// next four tests pin the chained behaviour: known-token redaction
+// keeps working; planted token-shaped strings get pattern-scrubbed;
+// both together for a realistic mixed payload.
+
+func TestSanitiseOutputChainKnownTokenStillRedacted(t *testing.T) {
+	// Regression assertion for the original #152 contract: when a
+	// known GITHUB_TOKEN value is supplied, it is substring-redacted
+	// to the [REDACTED] sentinel regardless of pattern shape.
+	token := "ghp_thisIsNotAValidPatternMatchTokenButCallerKnowsIt"
+	out := chips.SanitiseOutputForTest("emit "+token+" and stop", token)
+	if strings.Contains(out, token) {
+		t.Errorf("known token surfaced: %q", out)
+	}
+	if !strings.Contains(out, redact.Sentinel) {
+		t.Errorf("expected %q sentinel in output: %q", redact.Sentinel, out)
+	}
+}
+
+func TestSanitiseOutputChainPlantedTokenPatternRedacted(t *testing.T) {
+	// The new #83 contract: a token-SHAPE the operator never supplied
+	// as a known secret (because it was planted by a third party in a
+	// GitHub comment body) gets caught by pattern matching even though
+	// the caller passes an empty / different token.
+	planted := "AKIA" + strings.Repeat("Q", 16)
+	out := chips.SanitiseOutputForTest("attacker planted: "+planted+" here", "")
+	if strings.Contains(out, planted) {
+		t.Errorf("planted token surfaced: %q", out)
+	}
+	if !strings.Contains(out, "AKIA…REDACTED") {
+		t.Errorf("expected pattern sentinel: %q", out)
+	}
+}
+
+func TestSanitiseOutputChainBothPathsTogether(t *testing.T) {
+	// A realistic mixed payload: the gh-shell command sometimes echoes
+	// the configured token, and an attacker plants a different
+	// secret-shape in an issue body. Both must redact.
+	token := "ghp_realOperatorTokenValueKnownLiterally"
+	planted := "AKIA" + strings.Repeat("J", 16)
+	in := "tool error: " + token + "\nissue body: " + planted + "\n"
+	out := chips.SanitiseOutputForTest(in, token)
+	if strings.Contains(out, token) {
+		t.Errorf("known token surfaced: %q", out)
+	}
+	if strings.Contains(out, planted) {
+		t.Errorf("planted token surfaced: %q", out)
+	}
+	if !strings.Contains(out, redact.Sentinel) {
+		t.Errorf("expected substring sentinel: %q", out)
+	}
+	if !strings.Contains(out, "AKIA…REDACTED") {
+		t.Errorf("expected pattern sentinel: %q", out)
+	}
+}
+
+func TestSanitiseOutputChainEmptyTokenStillSanitisesPatterns(t *testing.T) {
+	// Pre-#83 behaviour: empty token meant no substring redaction
+	// happened. Post-#83: pattern-based Sanitise still runs even when
+	// the caller has no known secret to redact.
+	in := "comment: ghp_" + strings.Repeat("M", 40) + " end"
+	out := chips.SanitiseOutputForTest(in, "")
+	if !strings.Contains(out, "ghp_…REDACTED") {
+		t.Errorf("expected pattern sentinel with empty token: %q", out)
+	}
+}

--- a/internal/tools/chips/sanitise_test.go
+++ b/internal/tools/chips/sanitise_test.go
@@ -8,34 +8,96 @@ import (
 	"klazomenai/bridge/internal/tools/redact"
 )
 
-// TestChipsSanitisePerPatternPositive pins that chips.Sanitise — not
-// just the underlying redact.Sanitise — applies every named pattern.
-// Per-pattern negative cases live in internal/tools/redact/redact_test.go
-// alongside the pattern definitions; this table is the chips-side
-// delegation contract demanded by #83's AC: "Unit tests in
-// internal/tools/chips/sanitise_test.go cover each pattern".
-func TestChipsSanitisePerPatternPositive(t *testing.T) {
+// TestChipsSanitisePerPatternPositiveAndNegative pins that
+// chips.Sanitise — not just the underlying redact.Sanitise — both
+// applies every named pattern to a positive case AND leaves a
+// near-miss input unchanged at the chips boundary. Satisfies #83's
+// AC: "Unit tests in internal/tools/chips/sanitise_test.go cover
+// each pattern with at least one positive and one false-positive
+// case". Negative fixtures mirror the per-pattern boundary cases in
+// internal/tools/redact/redact_test.go and are pinned again here so
+// the wrapper layer's contract is verified directly rather than
+// indirectly through the redact tests.
+func TestChipsSanitisePerPatternPositiveAndNegative(t *testing.T) {
 	cases := []struct {
 		name        string
-		input       string
+		positive    string
+		negative    string
 		mustContain string
 	}{
-		{"aws_access_key", "comment body: AKIATESTKEY012345678 planted by attacker", "AKIA…REDACTED"},
-		{"github_token_ghp", "Hey check out this PAT: ghp_" + strings.Repeat("Z", 40) + " — please rotate", "ghp_…REDACTED"},
-		{"github_token_ghu", "leaked user token ghu_" + strings.Repeat("B", 40) + " end", "ghu_…REDACTED"},
-		{"github_pat", "found token github_pat_" + strings.Repeat("C", 30) + " in logs", "github_pat_…REDACTED"},
-		{"openai_anthropic_key", "claude key sk-ant-" + strings.Repeat("d", 40) + " in comment", "sk-…REDACTED"},
-		{"slack_token", "slack bot tok xoxb-1234567890-abcde-fghijk in body", "xoxb-…REDACTED"},
-		{"jwt", "auth=eyJ-TEST-HEADER-PART.eyJ-TEST-PAYLOAD-PART.TEST-SIGNATURE-PART rest", "JWT-REDACTED"},
-		{"pem_block", "found:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAA\nKCAQEA\n-----END RSA PRIVATE KEY-----\nin comment", "-----BEGIN … KEY----- REDACTED -----END … KEY-----"},
-		{"bearer_token", "Authorization: Bearer abc123def456ghi.789-jkl_mno", "Bearer REDACTED"},
-		{"password_assignment", "config snippet password: hunter2-but-longer", "password: REDACTED"},
+		{
+			name:        "aws_access_key",
+			positive:    "comment body: AKIATESTKEY012345678 planted by attacker",
+			negative:    "operator note: AKIAtypo here in body",
+			mustContain: "AKIA…REDACTED",
+		},
+		{
+			name:        "github_token_ghp",
+			positive:    "Hey check out this PAT: ghp_" + strings.Repeat("Z", 40) + " — please rotate",
+			negative:    "stub token ghp_short in comment",
+			mustContain: "ghp_…REDACTED",
+		},
+		{
+			name:        "github_token_ghu",
+			positive:    "leaked user token ghu_" + strings.Repeat("B", 40) + " end",
+			negative:    "tok ghu_too_short for the class match",
+			mustContain: "ghu_…REDACTED",
+		},
+		{
+			name:        "github_pat",
+			positive:    "found token github_pat_" + strings.Repeat("C", 30) + " in logs",
+			negative:    "github_pat_short fixture",
+			mustContain: "github_pat_…REDACTED",
+		},
+		{
+			name:        "openai_anthropic_key",
+			positive:    "claude key sk-ant-" + strings.Repeat("d", 40) + " in comment",
+			negative:    "snippet sk-x truncated here",
+			mustContain: "sk-…REDACTED",
+		},
+		{
+			name:        "slack_token",
+			positive:    "slack bot tok xoxb-1234567890-abcde-fghijk in body",
+			negative:    "fixture xoxq-not-a-slack-shape here",
+			mustContain: "xoxb-…REDACTED",
+		},
+		{
+			name:        "jwt",
+			positive:    "auth=eyJ-TEST-HEADER-PART.eyJ-TEST-PAYLOAD-PART.TEST-SIGNATURE-PART rest",
+			negative:    "auth=eyJonly-no-second-segment here",
+			mustContain: "JWT-REDACTED",
+		},
+		{
+			name:        "pem_block",
+			positive:    "found:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAA\nKCAQEA\n-----END RSA PRIVATE KEY-----\nin comment",
+			negative:    "no envelope here, just the word BEGIN by itself",
+			mustContain: "-----BEGIN … KEY----- REDACTED -----END … KEY-----",
+		},
+		{
+			name:        "bearer_token",
+			positive:    "Authorization: Bearer abc123def456ghi.789-jkl_mno",
+			negative:    "the bearer of bad news arrived early",
+			mustContain: "Bearer REDACTED",
+		},
+		{
+			name:        "password_assignment",
+			positive:    "config snippet password: hunter2-but-longer",
+			negative:    "passwordless flow needs more docs",
+			mustContain: "password: REDACTED",
+		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			out := chips.Sanitise(tc.input)
+		t.Run(tc.name+"/positive", func(t *testing.T) {
+			out := chips.Sanitise(tc.positive)
 			if !strings.Contains(out, tc.mustContain) {
 				t.Errorf("expected %q in output, got: %q", tc.mustContain, out)
+			}
+		})
+		t.Run(tc.name+"/negative", func(t *testing.T) {
+			out := chips.Sanitise(tc.negative)
+			if out != tc.negative {
+				t.Errorf("near-miss input altered at chips boundary: %q → %q",
+					tc.negative, out)
 			}
 		})
 	}

--- a/internal/tools/chips/sanitise_test.go
+++ b/internal/tools/chips/sanitise_test.go
@@ -85,11 +85,15 @@ func TestChipsSanitiseIdempotence(t *testing.T) {
 	}
 }
 
-func TestChipsSanitiseFailClosedSurfaceMatchesRedact(t *testing.T) {
-	// Chips Sanitise delegates to redact.SanitiseWith, so the
-	// fail-closed contract is inherited. Verifying empty input is
-	// the smoke test that the wrapper does not introduce its own
-	// failure surface ahead of redact's recover.
+func TestChipsSanitiseEmptyInputUnchanged(t *testing.T) {
+	// Smoke test that the chips wrapper passes empty input through
+	// without introducing its own failure surface ahead of the
+	// redact-level recover. The fail-closed contract itself (panic
+	// recovery, SanitiserErrorReplacement substitution) is exercised
+	// in internal/tools/redact's TestSanitiseFailClosedOnPanic via
+	// a nil-regex Pattern injection through SanitiseWith — chips
+	// inherits that contract directly because allChipsPatterns
+	// composes a slice that ends up at the same SanitiseWith call.
 	if out := chips.Sanitise(""); out != "" {
 		t.Errorf("empty input altered: %q", out)
 	}

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -1,22 +1,131 @@
 // Package redact provides token redaction primitives for tool output
 // before it reaches the model, the user, or the audit log.
 //
-// The package is intentionally minimal: a variadic Redact function that
-// substitutes a sentinel for each known secret. Callers are responsible
-// for deciding which strings to treat as secrets — this package does
-// not detect tokens; it only redacts known ones.
+// Two complementary primitives:
+//
+//   - Redact substitutes a sentinel for each caller-supplied secret
+//     value. The package does not detect tokens; it only redacts known
+//     ones. Use this when the secret value is known at the call site
+//     (e.g. the GITHUB_TOKEN passed to a tool).
+//
+//   - Sanitise detects token-shaped strings in untrusted input via a
+//     regex pattern set and replaces them with informative sentinels.
+//     Use this when the input is attacker-controllable (e.g. GitHub
+//     comment bodies, email previews) and the value cannot be known
+//     in advance.
 //
 // For structured redaction (e.g. kubectl YAML field stripping), see the
-// per-package redaction layered on top of Redact (e.g. internal/tools/maren).
+// per-package redaction layered on top of these primitives (e.g.
+// internal/tools/maren).
 package redact
 
 import (
+	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 )
 
-// Sentinel is the replacement string substituted for each redacted secret.
+// Sentinel is the replacement string substituted for each Redacted secret.
 const Sentinel = "[REDACTED]"
+
+// MaxSanitiserInputBytes is the upper byte length Sanitise will process.
+// Inputs longer than this are truncated to this length before pattern
+// matching begins. The cap defends against regex-DoS amplification on
+// attacker-controlled bodies (a 1 MB pathological comment costs ~16 ×
+// 65 KB regex passes, not ~16 × 1 MB).
+//
+// Truncation may split a multi-byte UTF-8 rune at the boundary; the
+// resulting trailing invalid byte is harmless under Go's regexp (which
+// skips invalid UTF-8 in pattern character classes) and is preferred to
+// rune-walking for a hot-path defence.
+const MaxSanitiserInputBytes = 65536
+
+// SanitiserErrorReplacement is substituted for the entire input when
+// Sanitise's internal recover catches a panic. Callers MUST treat this
+// as a load-bearing safety floor: Bridge does not pass un-Sanitised
+// content to Claude under any circumstances, so a panic-replacement
+// surfacing to the model is a far better failure mode than silently
+// forwarding raw content.
+const SanitiserErrorReplacement = "[SANITISER ERROR — content suppressed]"
+
+// Pattern describes a single Sanitiser rule: a name (for log
+// attribution and per-pattern testing), a compiled regex to match,
+// and a replacement string substituted for each match.
+//
+// Replacements should be chosen so that re-applying Sanitise produces
+// the same output (idempotence). The default Patterns set below uses
+// the U+2026 horizontal ellipsis "…" in replacements to break the
+// originating character classes — `ghp_…REDACTED` does not re-match
+// `(ghp|gho|...)_[A-Za-z0-9]{36,}` because `…` is multi-byte and
+// outside the ASCII letter/digit class.
+type Pattern struct {
+	Name        string
+	Regex       *regexp.Regexp
+	Replacement string
+}
+
+// Patterns is the shared default Sanitiser pattern set. Order is
+// significant only when two patterns could match overlapping input;
+// the broader patterns (bearer, password) come last to give the
+// narrower token-shape patterns first opportunity.
+//
+// Adding a pattern here makes it apply to every consumer of
+// Sanitise (chips, crest, maren, the orchestrator-level safety floor).
+// For per-crew patterns that should NOT apply elsewhere, declare a
+// local []Pattern slice in the consumer's package and call
+// SanitiseWith.
+var Patterns = []Pattern{
+	{
+		Name:        "aws_access_key",
+		Regex:       regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+		Replacement: "AKIA…REDACTED",
+	},
+	{
+		Name:        "github_token",
+		Regex:       regexp.MustCompile(`(ghp|gho|ghr|ghu|ghs)_[A-Za-z0-9]{36,}`),
+		Replacement: "${1}_…REDACTED",
+	},
+	{
+		Name:        "github_pat",
+		Regex:       regexp.MustCompile(`github_pat_[A-Za-z0-9_]{22,}`),
+		Replacement: "github_pat_…REDACTED",
+	},
+	{
+		Name:        "openai_anthropic_key",
+		Regex:       regexp.MustCompile(`sk-(ant-)?[A-Za-z0-9_\-]{20,}`),
+		Replacement: "sk-…REDACTED",
+	},
+	{
+		Name:        "slack_token",
+		Regex:       regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),
+		Replacement: "xox-…REDACTED",
+	},
+	{
+		Name:        "jwt",
+		Regex:       regexp.MustCompile(`eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+`),
+		Replacement: "JWT-REDACTED",
+	},
+	{
+		Name:        "pem_block",
+		Regex:       regexp.MustCompile(`(?s)-----BEGIN [A-Z ]+ KEY-----.*?-----END [A-Z ]+ KEY-----`),
+		Replacement: "-----BEGIN … KEY----- REDACTED -----END … KEY-----",
+	},
+	{
+		Name: "bearer_token",
+		// {16,} avoids false-positives on English usage of the word
+		// bearer ("the bearer of bad news", "bearer bond holder")
+		// while still catching realistic OAuth / API bearer tokens,
+		// which are universally 20+ chars (JWTs are 100+).
+		Regex:       regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-]{16,}`),
+		Replacement: "Bearer REDACTED",
+	},
+	{
+		Name:        "password_assignment",
+		Regex:       regexp.MustCompile(`(?i)password\s*[:=]\s*\S+`),
+		Replacement: "password: REDACTED",
+	},
+}
 
 // Redact returns input with every non-empty secret in secrets replaced
 // by Sentinel. Empty secrets are skipped (so callers can pass through
@@ -46,4 +155,43 @@ func Redact(input string, secrets ...string) string {
 		input = strings.ReplaceAll(input, secret, Sentinel)
 	}
 	return input
+}
+
+// Sanitise runs the shared Patterns set over input. Inputs longer
+// than MaxSanitiserInputBytes are truncated before pattern matching.
+// See SanitiseWith for the failure-mode contract.
+func Sanitise(input string) string {
+	return SanitiseWith(input, Patterns)
+}
+
+// SanitiseWith runs the supplied pattern set over input with the same
+// length-ceiling and fail-closed guarantees as Sanitise.
+//
+// Fail-closed: any panic during pattern application is recovered, the
+// entire return value is replaced with SanitiserErrorReplacement, and
+// an slog.Error line is emitted with the panic value and the input
+// byte length (NOT the input itself — leaking a suspected-toxic
+// payload into logs would defeat the redaction).
+func SanitiseWith(input string, patterns []Pattern) (out string) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("sanitiser panic recovered",
+				"panic", r,
+				"input_bytes", len(input),
+			)
+			out = SanitiserErrorReplacement
+		}
+	}()
+
+	// Truncate before any pattern matching — guards against
+	// regex-DoS on attacker-controlled inputs.
+	if len(input) > MaxSanitiserInputBytes {
+		input = input[:MaxSanitiserInputBytes]
+	}
+
+	out = input
+	for _, p := range patterns {
+		out = p.Regex.ReplaceAllString(out, p.Replacement)
+	}
+	return out
 }

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -26,14 +26,15 @@ import (
 	"strings"
 )
 
-// Sentinel is the replacement string substituted for each Redacted secret.
+// Sentinel is the replacement string substituted for each redacted secret.
 const Sentinel = "[REDACTED]"
 
 // MaxSanitiserInputBytes is the upper byte length Sanitise will process.
 // Inputs longer than this are truncated to this length before pattern
 // matching begins. The cap defends against regex-DoS amplification on
-// attacker-controlled bodies (a 1 MB pathological comment costs ~16 ×
-// 65 KB regex passes, not ~16 × 1 MB).
+// attacker-controlled bodies — a pathological 1 MB comment costs
+// len(Patterns) × 65 KB regex passes, not len(Patterns) × 1 MB, no
+// matter how many patterns are added to the default set later.
 //
 // Truncation may split a multi-byte UTF-8 rune at the boundary; the
 // resulting trailing invalid byte is harmless under Go's regexp (which
@@ -97,9 +98,13 @@ var Patterns = []Pattern{
 		Replacement: "sk-…REDACTED",
 	},
 	{
-		Name:        "slack_token",
-		Regex:       regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),
-		Replacement: "xox-…REDACTED",
+		Name: "slack_token",
+		// Capture the type char (b/a/p/r/s) so the sentinel preserves
+		// which Slack token shape was redacted — useful when reading
+		// sanitised output for incident debugging (xoxb-…REDACTED is a
+		// bot token; xoxp-…REDACTED is a user token; etc.).
+		Regex:       regexp.MustCompile(`xox([baprs])-[A-Za-z0-9-]{10,}`),
+		Replacement: "xox${1}-…REDACTED",
 	},
 	{
 		Name:        "jwt",
@@ -121,9 +126,15 @@ var Patterns = []Pattern{
 		Replacement: "Bearer REDACTED",
 	},
 	{
-		Name:        "password_assignment",
-		Regex:       regexp.MustCompile(`(?i)password\s*[:=]\s*\S+`),
-		Replacement: "password: REDACTED",
+		Name: "password_assignment",
+		// Capture the matched keyword + delimiter so original case
+		// and the chosen delimiter survive the redaction — env-var
+		// style (DATABASE_PASSWORD=...) stays readable as
+		// DATABASE_PASSWORD=REDACTED rather than being mangled to
+		// DATABASE_password: REDACTED. Case-insensitive match
+		// preserves the operator's writing convention.
+		Regex:       regexp.MustCompile(`(?i)(password\s*[:=]\s*)\S+`),
+		Replacement: "${1}REDACTED",
 	},
 }
 

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -53,6 +53,13 @@ func getLogger() *slog.Logger {
 // (Error) events. Returns a restore function that re-installs the
 // previous logger; defer the restore in tests.
 //
+// Passing nil resets the package back to slog.Default — this avoids
+// the failure mode where a caller-supplied nil logger would cause
+// getLogger to return nil and the next emission to panic inside the
+// recover handler itself, escaping the fail-closed guarantee. The
+// restore function returned for a nil call still rolls back to
+// whatever logger was installed before this call.
+//
 // Two intended use cases:
 //
 //  1. Test capture: install a logger backed by a bytes.Buffer
@@ -69,7 +76,11 @@ func SetLogger(l *slog.Logger) (restore func()) {
 	loggerMu.Lock()
 	defer loggerMu.Unlock()
 	prev := loggerGetter
-	loggerGetter = func() *slog.Logger { return l }
+	if l == nil {
+		loggerGetter = slog.Default
+	} else {
+		loggerGetter = func() *slog.Logger { return l }
+	}
 	return func() {
 		loggerMu.Lock()
 		defer loggerMu.Unlock()

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -29,12 +29,14 @@ import (
 // Sentinel is the replacement string substituted for each redacted secret.
 const Sentinel = "[REDACTED]"
 
-// MaxSanitiserInputBytes is the upper byte length Sanitise will process.
-// Inputs longer than this are truncated to this length before pattern
-// matching begins. The cap defends against regex-DoS amplification on
-// attacker-controlled bodies — a pathological 1 MB comment costs
-// len(Patterns) × 65 KB regex passes, not len(Patterns) × 1 MB, no
-// matter how many patterns are added to the default set later.
+// MaxSanitiserInputBytes is the upper byte length Sanitise will process
+// (64 KiB exactly = 65 536 bytes). Inputs longer than this are
+// truncated to this length before pattern matching begins. The cap
+// defends against regex-DoS amplification on attacker-controlled
+// bodies: pattern-matching cost is bounded to N × 64 KiB regex
+// passes (N = number of patterns in the default set) rather than
+// N × original-input-size, regardless of how many patterns are added
+// later.
 //
 // Truncation may split a multi-byte UTF-8 rune at the boundary; the
 // resulting trailing invalid byte is harmless under Go's regexp (which
@@ -66,17 +68,20 @@ type Pattern struct {
 	Replacement string
 }
 
-// Patterns is the shared default Sanitiser pattern set. Order is
-// significant only when two patterns could match overlapping input;
-// the broader patterns (bearer, password) come last to give the
-// narrower token-shape patterns first opportunity.
+// defaultPatterns is the shared default Sanitiser pattern set,
+// unexported so external consumers cannot mutate it (append, reorder,
+// modify) and race with concurrent Sanitise calls. Use DefaultPatterns
+// to obtain a defensive copy.
 //
-// Adding a pattern here makes it apply to every consumer of
-// Sanitise (chips, crest, maren, the orchestrator-level safety floor).
-// For per-crew patterns that should NOT apply elsewhere, declare a
-// local []Pattern slice in the consumer's package and call
-// SanitiseWith.
-var Patterns = []Pattern{
+// Order is significant only when two patterns could match overlapping
+// input; the broader patterns (bearer, password) come last to give
+// the narrower token-shape patterns first opportunity.
+//
+// Adding a pattern here makes it apply to every consumer of Sanitise
+// (chips, crest, maren, the orchestrator-level safety floor). For
+// per-crew patterns that should NOT apply elsewhere, declare a local
+// []Pattern slice in the consumer's package and call SanitiseWith.
+var defaultPatterns = []Pattern{
 	{
 		Name:        "aws_access_key",
 		Regex:       regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
@@ -168,11 +173,28 @@ func Redact(input string, secrets ...string) string {
 	return input
 }
 
-// Sanitise runs the shared Patterns set over input. Inputs longer
-// than MaxSanitiserInputBytes are truncated before pattern matching.
-// See SanitiseWith for the failure-mode contract.
+// Sanitise runs the package default pattern set over input. Inputs
+// longer than MaxSanitiserInputBytes are truncated before pattern
+// matching. See SanitiseWith for the failure-mode contract.
 func Sanitise(input string) string {
-	return SanitiseWith(input, Patterns)
+	return SanitiseWith(input, defaultPatterns)
+}
+
+// DefaultPatterns returns a defensive copy of the shared default
+// pattern set applied by Sanitise. Use this when composing the
+// default set with per-crew extras (see chips.Sanitise for the
+// canonical pattern) so the underlying slice cannot be mutated by
+// downstream consumers and race with concurrent Sanitise calls.
+//
+// The returned slice is safe to mutate (append, reorder, modify
+// individual Patterns) without affecting Sanitise's behaviour for
+// other callers. Each call returns a fresh slice; do NOT cache the
+// return value if you intend to mutate it, or two consumers will
+// share the same backing array.
+func DefaultPatterns() []Pattern {
+	out := make([]Pattern, len(defaultPatterns))
+	copy(out, defaultPatterns)
+	return out
 }
 
 // SanitiseWith runs the supplied pattern set over input with the same

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -20,6 +20,7 @@
 package redact
 
 import (
+	"context"
 	"log/slog"
 	"regexp"
 	"sort"
@@ -175,9 +176,10 @@ func Redact(input string, secrets ...string) string {
 
 // Sanitise runs the package default pattern set over input. Inputs
 // longer than MaxSanitiserInputBytes are truncated before pattern
-// matching. See SanitiseWith for the failure-mode contract.
-func Sanitise(input string) string {
-	return SanitiseWith(input, defaultPatterns)
+// matching. See SanitiseWith for the failure-mode contract and the
+// attribution-logging contract.
+func Sanitise(input string, logAttrs ...slog.Attr) string {
+	return SanitiseWith(input, defaultPatterns, logAttrs...)
 }
 
 // DefaultPatterns returns a defensive copy of the shared default
@@ -224,7 +226,16 @@ func DefaultPatterns() []Pattern {
 // an slog.Error line is emitted with the panic value and the input
 // byte length (NOT the input itself — leaking a suspected-toxic
 // payload into logs would defeat the redaction).
-func SanitiseWith(input string, patterns []Pattern) (out string) {
+//
+// Attribution logging: when logAttrs is non-empty, every pattern
+// that matches at least once emits a single slog.Info line at the
+// "sanitiser_redaction" message with the caller's attrs (typically
+// `tool` and `field`) plus `pattern_name` (which pattern fired) and
+// `count` (how many matches were replaced). The matched text itself
+// is NEVER logged — leaking redacted content would defeat the
+// purpose. When logAttrs is empty (the default), no logging occurs
+// and the regex matching cost stays at one pass per pattern.
+func SanitiseWith(input string, patterns []Pattern, logAttrs ...slog.Attr) (out string) {
 	// Capture the original length BEFORE truncation so a deferred
 	// panic log reflects the actual payload size that crashed the
 	// sanitiser, not the post-truncation slice length. Useful for
@@ -257,7 +268,26 @@ func SanitiseWith(input string, patterns []Pattern) (out string) {
 
 	out = input
 	for _, p := range patterns {
+		// Attribution logging path: count matches BEFORE replacement
+		// so the log line reflects the real redaction events. Skipped
+		// entirely when logAttrs is empty to keep the no-log path at
+		// one regex pass per pattern (the FindAllStringIndex below
+		// would otherwise double the cost).
+		var matchCount int
+		if len(logAttrs) > 0 {
+			matchCount = len(p.Regex.FindAllStringIndex(out, -1))
+		}
 		out = p.Regex.ReplaceAllString(out, p.Replacement)
+		if matchCount > 0 {
+			allAttrs := make([]slog.Attr, 0, len(logAttrs)+2)
+			allAttrs = append(allAttrs, logAttrs...)
+			allAttrs = append(allAttrs,
+				slog.String("pattern_name", p.Name),
+				slog.Int("count", matchCount),
+			)
+			slog.LogAttrs(context.Background(), slog.LevelInfo,
+				"sanitiser_redaction", allAttrs...)
+		}
 	}
 
 	// Truncate OUTPUT to the same cap. Some pattern replacements run

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -25,7 +25,57 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 )
+
+// loggerMu guards the swappable package-level logger function below.
+// Reads via getLogger are RLock-only and run on every Sanitise event;
+// writes via SetLogger Lock the mutex briefly. Per-process state —
+// `go test ./internal/...` runs each package as a separate binary so
+// there is no cross-package interference, and within-package tests
+// run sequentially by default. The mutex is defence against a future
+// caller adding t.Parallel() or running multiple sanitiser goroutines.
+var (
+	loggerMu     sync.RWMutex
+	loggerGetter = slog.Default
+)
+
+// getLogger returns the slog.Logger configured for sanitiser
+// emissions. Defaults to slog.Default; overridable via SetLogger.
+func getLogger() *slog.Logger {
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+	return loggerGetter()
+}
+
+// SetLogger overrides the slog.Logger used to emit
+// "sanitiser_redaction" (Info) and "sanitiser panic recovered"
+// (Error) events. Returns a restore function that re-installs the
+// previous logger; defer the restore in tests.
+//
+// Two intended use cases:
+//
+//  1. Test capture: install a logger backed by a bytes.Buffer
+//     handler to assert on emission attrs without mutating
+//     slog.Default (which would race with other packages' tests
+//     under hypothetical parallel test execution).
+//  2. Production routing: operators who want sanitiser telemetry
+//     on a dedicated handler (separate file, different level
+//     threshold, structured handler) can install one at startup.
+//
+// Concurrent SetLogger and Sanitise calls are safe — the internal
+// mutex serialises writes against the RLock'd read path.
+func SetLogger(l *slog.Logger) (restore func()) {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+	prev := loggerGetter
+	loggerGetter = func() *slog.Logger { return l }
+	return func() {
+		loggerMu.Lock()
+		defer loggerMu.Unlock()
+		loggerGetter = prev
+	}
+}
 
 // Sentinel is the replacement string substituted for each redacted secret.
 const Sentinel = "[REDACTED]"
@@ -245,11 +295,20 @@ func SanitiseWith(input string, patterns []Pattern, logAttrs ...slog.Attr) (out 
 
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("sanitiser panic recovered",
-				"panic", r,
-				"input_bytes", origLen,
-				"truncated", origLen > MaxSanitiserInputBytes,
+			// Include caller-supplied attribution (tool/field) in the
+			// recover log so an operator triaging "which tool's
+			// sanitiser blew up?" can answer it from the log line
+			// alone, not by cross-referencing timestamps. The raw
+			// input is still NEVER logged (only its length).
+			recoverAttrs := make([]slog.Attr, 0, len(logAttrs)+3)
+			recoverAttrs = append(recoverAttrs, logAttrs...)
+			recoverAttrs = append(recoverAttrs,
+				slog.Any("panic", r),
+				slog.Int("input_bytes", origLen),
+				slog.Bool("truncated", origLen > MaxSanitiserInputBytes),
 			)
+			getLogger().LogAttrs(context.Background(), slog.LevelError,
+				"sanitiser panic recovered", recoverAttrs...)
 			out = SanitiserErrorReplacement
 		}
 	}()
@@ -268,16 +327,26 @@ func SanitiseWith(input string, patterns []Pattern, logAttrs ...slog.Attr) (out 
 
 	out = input
 	for _, p := range patterns {
-		// Attribution logging path: count matches BEFORE replacement
-		// so the log line reflects the real redaction events. Skipped
-		// entirely when logAttrs is empty to keep the no-log path at
-		// one regex pass per pattern (the FindAllStringIndex below
-		// would otherwise double the cost).
-		var matchCount int
-		if len(logAttrs) > 0 {
-			matchCount = len(p.Regex.FindAllStringIndex(out, -1))
+		if len(logAttrs) == 0 {
+			// Hot path (no attribution requested — orchestrator floor
+			// in #129, direct tests): single regex pass per pattern.
+			out = p.Regex.ReplaceAllString(out, p.Replacement)
+			continue
 		}
-		out = p.Regex.ReplaceAllString(out, p.Replacement)
+		// Attribution path: count matches and replace in a single
+		// outer scan via ReplaceAllStringFunc. The closure receives
+		// each matched substring; we re-apply the pattern inside it
+		// to honour capture-group replacements like `${1}_…REDACTED`,
+		// at a cost of O(|match|) per match. Total cost is
+		// O(|input|) + O(Σ|match|) rather than the 2×O(|input|) a
+		// separate FindAll+Replace would pay — important because
+		// every chips production call passes attrs, putting this
+		// branch on the hot path.
+		matchCount := 0
+		out = p.Regex.ReplaceAllStringFunc(out, func(match string) string {
+			matchCount++
+			return p.Regex.ReplaceAllString(match, p.Replacement)
+		})
 		if matchCount > 0 {
 			allAttrs := make([]slog.Attr, 0, len(logAttrs)+2)
 			allAttrs = append(allAttrs, logAttrs...)
@@ -285,7 +354,7 @@ func SanitiseWith(input string, patterns []Pattern, logAttrs ...slog.Attr) (out 
 				slog.String("pattern_name", p.Name),
 				slog.Int("count", matchCount),
 			)
-			slog.LogAttrs(context.Background(), slog.LevelInfo,
+			getLogger().LogAttrs(context.Background(), slog.LevelInfo,
 				"sanitiser_redaction", allAttrs...)
 		}
 	}

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -184,25 +184,47 @@ func Sanitise(input string) string {
 // byte length (NOT the input itself — leaking a suspected-toxic
 // payload into logs would defeat the redaction).
 func SanitiseWith(input string, patterns []Pattern) (out string) {
+	// Capture the original length BEFORE truncation so a deferred
+	// panic log reflects the actual payload size that crashed the
+	// sanitiser, not the post-truncation slice length. Useful for
+	// incident triage ("how big was the toxic payload?") and lost
+	// otherwise because `input` is reassigned below.
+	origLen := len(input)
+
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("sanitiser panic recovered",
 				"panic", r,
-				"input_bytes", len(input),
+				"input_bytes", origLen,
+				"truncated", origLen > MaxSanitiserInputBytes,
 			)
 			out = SanitiserErrorReplacement
 		}
 	}()
 
-	// Truncate before any pattern matching — guards against
+	// Truncate INPUT before any pattern matching — guards against
 	// regex-DoS on attacker-controlled inputs.
-	if len(input) > MaxSanitiserInputBytes {
+	if origLen > MaxSanitiserInputBytes {
 		input = input[:MaxSanitiserInputBytes]
 	}
 
 	out = input
 	for _, p := range patterns {
 		out = p.Regex.ReplaceAllString(out, p.Replacement)
+	}
+
+	// Truncate OUTPUT to the same cap. Some pattern replacements run
+	// slightly longer than their minimal input match — the U+2026
+	// ellipsis is 3 UTF-8 bytes where the matched byte was 1 ASCII —
+	// so an adversarial body packed with minimal-length matches (e.g.
+	// 4096 `xoxb-1234567890 ` units = exactly 65 536 bytes) would
+	// produce output of 69 632 bytes without this cap. Re-truncating
+	// preserves the byte-budget invariant for downstream consumers
+	// (notably the orchestrator-level safety floor in #129, which
+	// chains another Sanitise pass and benefits from a known upper
+	// bound on its own input size).
+	if len(out) > MaxSanitiserInputBytes {
+		out = out[:MaxSanitiserInputBytes]
 	}
 	return out
 }

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -186,11 +186,17 @@ func Sanitise(input string) string {
 // canonical pattern) so the underlying slice cannot be mutated by
 // downstream consumers and race with concurrent Sanitise calls.
 //
-// The returned slice is safe to mutate (append, reorder, modify
-// individual Patterns) without affecting Sanitise's behaviour for
-// other callers. Each call returns a fresh slice; do NOT cache the
-// return value if you intend to mutate it, or two consumers will
-// share the same backing array.
+// Each call returns an independent backing array — separate
+// DefaultPatterns calls do NOT share storage with each other or
+// with the unexported defaultPatterns. The returned slice is safe
+// to mutate (append, reorder, modify individual Patterns) without
+// affecting any other caller.
+//
+// The hazard to avoid is sharing a single mutated slice instance
+// across consumers (e.g. caching one DefaultPatterns() return in a
+// package-level var and letting two components append to it from
+// different code paths). If a consumer intends to mutate, it should
+// call DefaultPatterns afresh for its own copy.
 func DefaultPatterns() []Pattern {
 	out := make([]Pattern, len(defaultPatterns))
 	copy(out, defaultPatterns)
@@ -225,9 +231,15 @@ func SanitiseWith(input string, patterns []Pattern) (out string) {
 	}()
 
 	// Truncate INPUT before any pattern matching — guards against
-	// regex-DoS on attacker-controlled inputs.
+	// regex-DoS on attacker-controlled inputs. strings.Clone is
+	// load-bearing on the memory side of the cap: a bare
+	// `input[:Max]` slice retains the full original backing
+	// allocation via the string header's data pointer, so a 1 MiB
+	// attacker payload would stay alive in memory for as long as
+	// the truncated string did. Clone forces a fresh 64 KiB
+	// allocation and lets the original be GC'd.
 	if origLen > MaxSanitiserInputBytes {
-		input = input[:MaxSanitiserInputBytes]
+		input = strings.Clone(input[:MaxSanitiserInputBytes])
 	}
 
 	out = input
@@ -244,9 +256,12 @@ func SanitiseWith(input string, patterns []Pattern) (out string) {
 	// preserves the byte-budget invariant for downstream consumers
 	// (notably the orchestrator-level safety floor in #129, which
 	// chains another Sanitise pass and benefits from a known upper
-	// bound on its own input size).
+	// bound on its own input size). Clone for the same memory-defence
+	// reason as the input path: a pre-truncation `out` longer than
+	// the cap stays alive via the truncated slice's backing pointer
+	// otherwise.
 	if len(out) > MaxSanitiserInputBytes {
-		out = out[:MaxSanitiserInputBytes]
+		out = strings.Clone(out[:MaxSanitiserInputBytes])
 	}
 	return out
 }

--- a/internal/tools/redact/redact.go
+++ b/internal/tools/redact/redact.go
@@ -187,16 +187,29 @@ func Sanitise(input string) string {
 // downstream consumers and race with concurrent Sanitise calls.
 //
 // Each call returns an independent backing array — separate
-// DefaultPatterns calls do NOT share storage with each other or
-// with the unexported defaultPatterns. The returned slice is safe
-// to mutate (append, reorder, modify individual Patterns) without
-// affecting any other caller.
+// DefaultPatterns calls do NOT share slice storage with each other
+// or with the unexported defaultPatterns. The returned slice is
+// safe to mutate at the slice level (append, reorder, drop, or
+// replace whole Pattern values) without affecting any other caller.
 //
-// The hazard to avoid is sharing a single mutated slice instance
-// across consumers (e.g. caching one DefaultPatterns() return in a
-// package-level var and letting two components append to it from
-// different code paths). If a consumer intends to mutate, it should
-// call DefaultPatterns afresh for its own copy.
+// CAVEAT — pointer sharing on Pattern.Regex: the Regex field is a
+// *regexp.Regexp pointer that IS shared with the unexported
+// defaultPatterns (only the Pattern struct values are copied, not
+// the regex instances). Do NOT call mutating methods on a returned
+// Pattern's Regex (notably Regexp.Longest, which changes match mode)
+// — that change races with concurrent Sanitise calls and silently
+// alters every other consumer's matching behaviour. To substitute
+// a pattern, REPLACE the Pattern struct in the slice
+// (mySlice[i] = Pattern{Name: ..., Regex: regexp.MustCompile(...),
+// Replacement: ...}) rather than mutating the existing pattern's
+// fields in place.
+//
+// The hazard to avoid at the slice level is sharing a single
+// mutated slice instance across consumers (e.g. caching one
+// DefaultPatterns return in a package-level var and letting two
+// components append to it from different code paths). If a consumer
+// intends to mutate, it should call DefaultPatterns afresh for its
+// own copy.
 func DefaultPatterns() []Pattern {
 	out := make([]Pattern, len(defaultPatterns))
 	copy(out, defaultPatterns)

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -274,6 +274,38 @@ func TestSanitiseTruncationPreservesShortInputs(t *testing.T) {
 	}
 }
 
+func TestSanitiseOutputBoundedAtCapEvenWithExpandingReplacements(t *testing.T) {
+	// Some pattern replacements add bytes to the matched span — the
+	// U+2026 ellipsis sentinel is 3 UTF-8 bytes where the originating
+	// pattern character class only accepts 1-byte ASCII. Stack enough
+	// minimal-length matches to fill the input cap and the naive
+	// (no output re-truncation) implementation would produce output
+	// exceeding MaxSanitiserInputBytes by ~1 byte per match. The
+	// function caps output at MaxSanitiserInputBytes so downstream
+	// consumers (notably the orchestrator-level safety floor in #129)
+	// see a known byte budget regardless of input shape.
+	unit := "xoxb-1234567890 " // 16 bytes: 15-byte minimal match + space
+	units := redact.MaxSanitiserInputBytes / len(unit)
+	in := strings.Repeat(unit, units)
+	if len(in) != redact.MaxSanitiserInputBytes {
+		t.Fatalf("fixture broken: in is %d bytes, expected %d",
+			len(in), redact.MaxSanitiserInputBytes)
+	}
+
+	out := redact.Sanitise(in)
+
+	if len(out) > redact.MaxSanitiserInputBytes {
+		t.Errorf("output exceeds cap despite re-truncation: got %d bytes, cap %d",
+			len(out), redact.MaxSanitiserInputBytes)
+	}
+	// Pin that the test fixture actually exercised the replacement
+	// path — without this, an inert input could trivially pass the
+	// cap assertion.
+	if !strings.Contains(out, "xoxb-…REDACTED") {
+		t.Error("test fixture did not produce slack-token replacement; assertion above is vacuous")
+	}
+}
+
 func TestSanitiseEmptyInput(t *testing.T) {
 	if out := redact.Sanitise(""); out != "" {
 		t.Errorf("empty input altered: %q", out)

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -1,12 +1,27 @@
 package redact_test
 
 import (
+	"bytes"
+	"log/slog"
 	"regexp"
 	"strings"
 	"testing"
 
 	"klazomenai/bridge/internal/tools/redact"
 )
+
+// captureSlog replaces the default slog logger with one that writes
+// JSON to a buffer, returning the buffer and a restore function. Use
+// `defer restore()` in tests that need to assert on log output.
+func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+	return &buf, func() { slog.SetDefault(original) }
+}
 
 func TestRedactSingleSecretReplaced(t *testing.T) {
 	out := redact.Redact("token=ghp_abc123 user=root", "ghp_abc123")
@@ -433,6 +448,91 @@ func TestDefaultPatternsReturnsDefensiveCopy(t *testing.T) {
 	out := redact.Sanitise("planted AKIATESTKEY012345678 here")
 	if !strings.Contains(out, "AKIA…REDACTED") {
 		t.Errorf("Sanitise was disturbed by DefaultPatterns copy mutation: %q", out)
+	}
+}
+
+func TestSanitiseEmitsLogPerPatternMatchWithAttrs(t *testing.T) {
+	// AC10 (#83): each pattern that fires emits one slog.Info line
+	// with the caller's attrs (tool + field) plus pattern_name +
+	// count. Two distinct patterns + 2 AWS matches + 1 GH token match
+	// produces exactly 2 log lines (one per pattern), with counts 2
+	// and 1 respectively.
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	in := "leaked AKIATESTKEY012345678 and AKIATESTKEY999999999 and tok ghp_" +
+		strings.Repeat("A", 40) + " end"
+	_ = redact.Sanitise(in,
+		slog.String("tool", "test_tool"),
+		slog.String("field", "output"),
+	)
+
+	logOut := buf.String()
+	if !strings.Contains(logOut, `"tool":"test_tool"`) {
+		t.Errorf("expected tool attr in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"field":"output"`) {
+		t.Errorf("expected field attr in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"pattern_name":"aws_access_key"`) {
+		t.Errorf("expected aws_access_key pattern_name in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"pattern_name":"github_token"`) {
+		t.Errorf("expected github_token pattern_name in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"count":2`) {
+		t.Errorf("expected count=2 for two AWS matches, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"count":1`) {
+		t.Errorf("expected count=1 for one GH token match, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"msg":"sanitiser_redaction"`) {
+		t.Errorf("expected sanitiser_redaction msg in log, got: %s", logOut)
+	}
+
+	// Critical: the matched values themselves MUST NOT appear in the
+	// log output (would defeat the purpose of redacting them).
+	if strings.Contains(logOut, "AKIATESTKEY012345678") {
+		t.Error("raw AWS key leaked into log output")
+	}
+	if strings.Contains(logOut, strings.Repeat("A", 40)) {
+		t.Error("raw GH token leaked into log output")
+	}
+}
+
+func TestSanitiseSilentWhenNoLogAttrs(t *testing.T) {
+	// AC10 (#83) inverse: no log attrs → no emission. The
+	// orchestrator-level safety floor (#129) and existing callers
+	// that pre-date logging stay silent so they don't double-log
+	// every redaction event.
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	in := "leaked AKIATESTKEY012345678 and ghp_" + strings.Repeat("Z", 40)
+	_ = redact.Sanitise(in) // no log attrs
+
+	if buf.Len() != 0 {
+		t.Errorf("expected silent sanitisation with no attrs, got log output: %s",
+			buf.String())
+	}
+}
+
+func TestSanitiseNoLogLineWhenZeroMatches(t *testing.T) {
+	// Even with attrs provided, a pattern that finds no matches must
+	// not emit a log line — log entries should map 1:1 to patterns
+	// that actually fired (avoids noise when sanitising benign text).
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	in := "completely benign text with no token shapes whatsoever"
+	_ = redact.Sanitise(in,
+		slog.String("tool", "test_tool"),
+		slog.String("field", "output"),
+	)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no log entries when zero patterns matched, got: %s",
+			buf.String())
 	}
 }
 

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -328,11 +328,30 @@ func TestSanitiseFailClosedOnPanic(t *testing.T) {
 	}
 }
 
-func TestSanitiseWithEmptyPatternsReturnsInputUnchanged(t *testing.T) {
+func TestSanitiseWithEmptyPatternsUnderCapReturnsInputUnchanged(t *testing.T) {
+	// Below the cap, an empty pattern set should short-circuit
+	// replacement and leave input bytes intact.
 	in := "anything here including AKIATESTKEY012345678"
 	out := redact.SanitiseWith(in, nil)
 	if out != in {
-		t.Errorf("empty pattern set altered input: %q → %q", in, out)
+		t.Errorf("empty pattern set altered under-cap input: %q → %q", in, out)
+	}
+}
+
+func TestSanitiseWithEmptyPatternsOverCapStillTruncates(t *testing.T) {
+	// The cap is enforced unconditionally — even with no patterns
+	// to apply, an oversized input is truncated to MaxSanitiserInputBytes
+	// before any pattern loop runs. This pins the contract that the
+	// length ceiling is a property of SanitiseWith itself, not of the
+	// pattern set.
+	in := strings.Repeat("a", redact.MaxSanitiserInputBytes+1000)
+	out := redact.SanitiseWith(in, nil)
+	if len(out) != redact.MaxSanitiserInputBytes {
+		t.Errorf("over-cap input not truncated to cap: got %d bytes, want %d",
+			len(out), redact.MaxSanitiserInputBytes)
+	}
+	if out != in[:redact.MaxSanitiserInputBytes] {
+		t.Error("over-cap truncated output differs from prefix of original input")
 	}
 }
 

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -355,6 +355,43 @@ func TestSanitiseWithCustomPattern(t *testing.T) {
 	}
 }
 
+func TestDefaultPatternsReturnsDefensiveCopy(t *testing.T) {
+	// Without the defensive copy, mutating the returned slice would
+	// permanently change the package default — accidental append in
+	// an init() somewhere could break sanitisation for all callers,
+	// and concurrent reads against a mutated slice can race.
+	copy1 := redact.DefaultPatterns()
+	copy2 := redact.DefaultPatterns()
+
+	if len(copy1) == 0 {
+		t.Fatal("DefaultPatterns returned empty slice; the default set must have at least one pattern")
+	}
+	if len(copy1) != len(copy2) {
+		t.Fatalf("DefaultPatterns calls returned different lengths: %d vs %d",
+			len(copy1), len(copy2))
+	}
+
+	// Mutate copy1[0] in place. The Pattern struct fields (Name,
+	// Replacement) are value-copied by the make+copy sequence, so
+	// this must not affect copy2 OR the internal default set.
+	original := copy1[0]
+	copy1[0] = redact.Pattern{Name: "MUTATED", Replacement: "MUTATED"}
+
+	if copy2[0].Name != original.Name {
+		t.Errorf("DefaultPatterns returned shared backing slice: copy1 mutation affected copy2 (%q != %q)",
+			copy2[0].Name, original.Name)
+	}
+
+	// Sanitise must still behave per the pre-mutation default set.
+	// Pick a fixture that exercises the first default pattern
+	// (AKIA) so this catches both backing-array sharing and any
+	// stale-pointer issues.
+	out := redact.Sanitise("planted AKIATESTKEY012345678 here")
+	if !strings.Contains(out, "AKIA…REDACTED") {
+		t.Errorf("Sanitise was disturbed by DefaultPatterns copy mutation: %q", out)
+	}
+}
+
 func TestSanitiserConstantsAreLoadBearing(t *testing.T) {
 	// These constants are part of the public contract (referenced by
 	// chips, the orchestrator floor #129, and future per-crew

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -546,6 +546,75 @@ func TestSanitiseNoLogLineWhenZeroMatches(t *testing.T) {
 	}
 }
 
+func TestSetLoggerNilResetsToDefault(t *testing.T) {
+	// SetLogger(nil) MUST treat the argument as a reset back to
+	// slog.Default — installing a nil logger would otherwise propagate
+	// to getLogger() and the next Sanitise emission would panic
+	// inside the recover handler itself, escaping the fail-closed
+	// guarantee that's the whole point of the recover.
+	restore := redact.SetLogger(nil)
+	defer restore()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Sanitise panicked after SetLogger(nil): %v", r)
+		}
+	}()
+	// Trigger both code paths that go through getLogger():
+	// (1) the per-pattern emission via Sanitise + attrs.
+	_ = redact.Sanitise("planted AKIATESTKEY012345678 here",
+		slog.String("tool", "x"),
+		slog.String("field", "y"),
+	)
+	// (2) the panic-recover emission inside SanitiseWith.
+	out := redact.SanitiseWith("anything", []redact.Pattern{
+		{Name: "nil_regex_panic", Regex: nil, Replacement: "x"},
+	},
+		slog.String("tool", "x"),
+		slog.String("field", "y"),
+	)
+	if out != redact.SanitiserErrorReplacement {
+		t.Errorf("expected fail-closed replacement after panic; got %q", out)
+	}
+}
+
+func TestSetLoggerRestoreUnwindsToPreviousLogger(t *testing.T) {
+	// Each SetLogger call returns a restore that rolls back to the
+	// logger installed at the moment of THAT call (not the original
+	// default). Nested install/restore unwinds in LIFO order; this
+	// matters when test helpers compose.
+	var first, second bytes.Buffer
+	firstLogger := slog.New(slog.NewJSONHandler(&first, nil))
+	secondLogger := slog.New(slog.NewJSONHandler(&second, nil))
+
+	restore1 := redact.SetLogger(firstLogger)
+	restore2 := redact.SetLogger(secondLogger)
+
+	// Emit while secondLogger is active → goes to `second`
+	_ = redact.Sanitise("a AKIATESTKEY012345678",
+		slog.String("tool", "x"), slog.String("field", "y"))
+	if first.Len() != 0 {
+		t.Errorf("first logger captured under second's install: %s", first.String())
+	}
+	if second.Len() == 0 {
+		t.Error("second logger captured nothing")
+	}
+
+	// Restore2 unwinds to firstLogger
+	restore2()
+	secondLenAtSwap := second.Len()
+	_ = redact.Sanitise("b AKIATESTKEY012345678",
+		slog.String("tool", "x"), slog.String("field", "y"))
+	if first.Len() == 0 {
+		t.Error("first logger received nothing after restore2")
+	}
+	if second.Len() != secondLenAtSwap {
+		t.Error("second logger still receiving after restore2")
+	}
+
+	restore1()
+}
+
 func TestSanitiserConstantsAreLoadBearing(t *testing.T) {
 	// These constants are part of the public contract (referenced by
 	// chips, the orchestrator floor #129, and future per-crew

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -1,6 +1,7 @@
 package redact_test
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -99,5 +100,238 @@ func TestRedactOverlappingSecretsLongerWinsRegardlessOfOrder(t *testing.T) {
 				t.Errorf("expected 2 sentinel substitutions, got %q", out)
 			}
 		})
+	}
+}
+
+// --- Sanitise tests ---
+
+// Each row carries a positive case (input that MUST be redacted) and
+// a near-miss negative case (input that MUST NOT be redacted) for one
+// pattern. The negative cases pin the regex boundaries: shorter than
+// the minimum length, wrong prefix shape, or missing the structural
+// delimiter that anchors the pattern.
+func TestSanitisePerPatternPositiveAndNegative(t *testing.T) {
+	cases := []struct {
+		name        string
+		positive    string
+		negative    string
+		mustContain string // must appear in Sanitised positive output
+	}{
+		{
+			name:        "aws_access_key",
+			positive:    "key=AKIATESTKEY012345678 rest",
+			negative:    "key=AKIAtypo rest",
+			mustContain: "AKIA…REDACTED",
+		},
+		{
+			name:        "github_token_ghp",
+			positive:    "token=ghp_" + strings.Repeat("A", 36) + " end",
+			negative:    "token=ghp_short end",
+			mustContain: "ghp_…REDACTED",
+		},
+		{
+			name:        "github_token_ghs",
+			positive:    "token=ghs_" + strings.Repeat("z", 40) + " end",
+			negative:    "token=ghs_too_short end",
+			mustContain: "ghs_…REDACTED",
+		},
+		{
+			name:        "github_pat",
+			positive:    "token=github_pat_" + strings.Repeat("X", 30) + " end",
+			negative:    "token=github_pat_short end",
+			mustContain: "github_pat_…REDACTED",
+		},
+		{
+			name:        "openai_anthropic_key",
+			positive:    "key=sk-" + strings.Repeat("a", 40) + " end",
+			negative:    "key=sk-tiny end",
+			mustContain: "sk-…REDACTED",
+		},
+		{
+			name:        "openai_anthropic_key_ant_prefix",
+			positive:    "key=sk-ant-" + strings.Repeat("b", 40) + " end",
+			negative:    "key=sk-ant-x end",
+			mustContain: "sk-…REDACTED",
+		},
+		{
+			name:        "slack_token_xoxb",
+			positive:    "tok=xoxb-1234567890-abcde-fghijk end",
+			negative:    "tok=xoxq-not-a-slack-shape end",
+			mustContain: "xox-…REDACTED",
+		},
+		{
+			name:        "jwt",
+			positive:    "auth=eyJ-TEST-HEADER-PART.eyJ-TEST-PAYLOAD-PART.TEST-SIGNATURE-PART end",
+			negative:    "auth=eyJonly.notajwt end",
+			mustContain: "JWT-REDACTED",
+		},
+		{
+			name: "pem_block",
+			positive: "prefix\n-----BEGIN RSA PRIVATE KEY-----\n" +
+				"MIIEpAIBAAKCAQEAxyz\n" +
+				"more lines here\n" +
+				"-----END RSA PRIVATE KEY-----\nsuffix",
+			negative:    "no envelope here, just BEGIN words",
+			mustContain: "-----BEGIN … KEY----- REDACTED -----END … KEY-----",
+		},
+		{
+			name:        "bearer_token",
+			positive:    "Authorization: Bearer abc123.def-456_xyz",
+			negative:    "berating someone with words",
+			mustContain: "Bearer REDACTED",
+		},
+		{
+			name:        "password_assignment_colon",
+			positive:    "config: password: hunter2-on-deck",
+			negative:    "passwordless flow note",
+			mustContain: "password: REDACTED",
+		},
+		{
+			name:        "password_assignment_equals",
+			positive:    "DATABASE_PASSWORD=p@ssw0rd-1!",
+			negative:    "passwordy text",
+			mustContain: "password: REDACTED",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/positive", func(t *testing.T) {
+			out := redact.Sanitise(tc.positive)
+			if !strings.Contains(out, tc.mustContain) {
+				t.Errorf("expected %q in output, got: %q", tc.mustContain, out)
+			}
+		})
+		t.Run(tc.name+"/negative", func(t *testing.T) {
+			out := redact.Sanitise(tc.negative)
+			if out != tc.negative {
+				t.Errorf("near-miss input altered: %q → %q", tc.negative, out)
+			}
+		})
+	}
+}
+
+func TestSanitiseIdempotence(t *testing.T) {
+	// Idempotence is the contract that the orchestrator-level safety
+	// floor (#129) relies on: per-tool sanitisation runs first, the
+	// floor runs again on the same content, and the second pass must
+	// be a no-op for un-tainted strings AND for strings whose tokens
+	// were already replaced. Without this, the sentinel itself could
+	// be re-matched and re-Sanitised into something unrecognisable.
+	inputs := []string{
+		"plain text without secrets",
+		"AKIATESTKEY012345678 one",
+		"token=ghp_" + strings.Repeat("X", 40),
+		"Authorization: Bearer abc-123",
+		"password: hunter2",
+		"key=sk-ant-" + strings.Repeat("a", 40),
+		"jwt=eyJ-TEST-HEADER-PART.eyJ-TEST-PAYLOAD-PART.TEST-SIGNATURE-PART",
+		"-----BEGIN RSA PRIVATE KEY-----\nMIIEpQ\n-----END RSA PRIVATE KEY-----",
+		"DATABASE_PASSWORD=secret123",
+	}
+	for _, in := range inputs {
+		t.Run(in[:min(len(in), 40)], func(t *testing.T) {
+			once := redact.Sanitise(in)
+			twice := redact.Sanitise(once)
+			if once != twice {
+				t.Errorf("not idempotent:\n  once:  %q\n  twice: %q", once, twice)
+			}
+		})
+	}
+}
+
+func TestSanitiseTruncatesInputAtMaxBytes(t *testing.T) {
+	// A token planted past the byte cap must NOT appear in the
+	// Sanitised output — truncation makes downstream consumers blind
+	// to the tail, which is the intended trade-off against regex-DoS
+	// amplification on attacker-controlled bodies.
+	prefix := strings.Repeat("a", redact.MaxSanitiserInputBytes)
+	tailToken := "AKIATESTKEY012345678" // valid AWS key shape (20 chars)
+	in := prefix + " " + tailToken
+	if len(in) <= redact.MaxSanitiserInputBytes {
+		t.Fatalf("test fixture broken: in is %d bytes, must exceed cap", len(in))
+	}
+
+	out := redact.Sanitise(in)
+
+	if len(out) > redact.MaxSanitiserInputBytes {
+		t.Errorf("output exceeds MaxSanitiserInputBytes: got %d bytes", len(out))
+	}
+	if strings.Contains(out, tailToken) {
+		t.Errorf("tail token surfaced past truncation: %q", out)
+	}
+	if strings.Contains(out, "AKIA…REDACTED") {
+		t.Error("tail token was processed (should have been truncated away before pattern matching)")
+	}
+}
+
+func TestSanitiseTruncationPreservesShortInputs(t *testing.T) {
+	// Inputs at or below the cap must pass through pattern matching
+	// untouched in length terms (modulo the pattern replacements).
+	in := "token=AKIATESTKEY012345678 rest"
+	out := redact.Sanitise(in)
+	if !strings.Contains(out, "AKIA…REDACTED") {
+		t.Errorf("expected redaction of short input, got: %q", out)
+	}
+}
+
+func TestSanitiseEmptyInput(t *testing.T) {
+	if out := redact.Sanitise(""); out != "" {
+		t.Errorf("empty input altered: %q", out)
+	}
+}
+
+func TestSanitiseFailClosedOnPanic(t *testing.T) {
+	// A panic-inducing pattern (nil Regex) routed through SanitiseWith
+	// MUST return SanitiserErrorReplacement, NOT the partially-Sanitised
+	// or un-Sanitised input. Bridge never passes un-Sanitised content
+	// to Claude, even when its own infrastructure fails — this test
+	// pins that contract.
+	panicPatterns := []redact.Pattern{
+		{Name: "nil_regex_panic", Regex: nil, Replacement: "x"},
+	}
+	out := redact.SanitiseWith("token=ghp_abc123", panicPatterns)
+	if out != redact.SanitiserErrorReplacement {
+		t.Errorf("expected SanitiserErrorReplacement %q, got %q",
+			redact.SanitiserErrorReplacement, out)
+	}
+}
+
+func TestSanitiseWithEmptyPatternsReturnsInputUnchanged(t *testing.T) {
+	in := "anything here including AKIATESTKEY012345678"
+	out := redact.SanitiseWith(in, nil)
+	if out != in {
+		t.Errorf("empty pattern set altered input: %q → %q", in, out)
+	}
+}
+
+func TestSanitiseWithCustomPattern(t *testing.T) {
+	// Demonstrates the SanitiseWith extension surface: a per-crew
+	// pattern slice can be passed alongside or instead of the shared
+	// redact.Patterns. Used by per-crew Sanitisers (chips, crest,
+	// maren) to add their own surface-specific patterns.
+	custom := []redact.Pattern{
+		{
+			Name:        "deck_chat_session",
+			Regex:       regexp.MustCompile(`dc_session_[0-9a-f]{16}`),
+			Replacement: "dc_session_…REDACTED",
+		},
+	}
+	in := "ref=dc_session_deadbeefcafef00d done"
+	out := redact.SanitiseWith(in, custom)
+	if !strings.Contains(out, "dc_session_…REDACTED") {
+		t.Errorf("custom pattern did not apply: %q", out)
+	}
+}
+
+func TestSanitiserConstantsAreLoadBearing(t *testing.T) {
+	// These constants are part of the public contract (referenced by
+	// chips, the orchestrator floor #129, and future per-crew
+	// Sanitisers). Pin them so a careless edit cannot silently relax
+	// the cap or change the panic-replacement marker.
+	if redact.MaxSanitiserInputBytes != 65536 {
+		t.Errorf("MaxSanitiserInputBytes drifted: got %d", redact.MaxSanitiserInputBytes)
+	}
+	if redact.SanitiserErrorReplacement != "[SANITISER ERROR — content suppressed]" {
+		t.Errorf("SanitiserErrorReplacement drifted: %q", redact.SanitiserErrorReplacement)
 	}
 }

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -339,8 +339,9 @@ func TestSanitiseWithEmptyPatternsReturnsInputUnchanged(t *testing.T) {
 func TestSanitiseWithCustomPattern(t *testing.T) {
 	// Demonstrates the SanitiseWith extension surface: a per-crew
 	// pattern slice can be passed alongside or instead of the shared
-	// redact.Patterns. Used by per-crew Sanitisers (chips, crest,
-	// maren) to add their own surface-specific patterns.
+	// redact default pattern set (DefaultPatterns / Sanitise). Used
+	// by per-crew Sanitisers (chips, crest, maren) to add their own
+	// surface-specific patterns.
 	custom := []redact.Pattern{
 		{
 			Name:        "deck_chat_session",

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -10,17 +10,19 @@ import (
 	"klazomenai/bridge/internal/tools/redact"
 )
 
-// captureSlog replaces the default slog logger with one that writes
-// JSON to a buffer, returning the buffer and a restore function. Use
-// `defer restore()` in tests that need to assert on log output.
+// captureSlog routes sanitiser emissions to a buffer via the
+// package-level redact.SetLogger swap (NOT slog.SetDefault, which
+// would mutate process-global state and could race with other
+// packages' tests under hypothetical parallel execution). Returns
+// the buffer and a restore function — defer the restore.
 func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
 	t.Helper()
 	var buf bytes.Buffer
-	original := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
-	})))
-	return &buf, func() { slog.SetDefault(original) }
+	}))
+	restore := redact.SetLogger(logger)
+	return &buf, restore
 }
 
 func TestRedactSingleSecretReplaced(t *testing.T) {
@@ -236,7 +238,15 @@ func TestSanitiseIdempotence(t *testing.T) {
 		"plain text without secrets",
 		"AKIATESTKEY012345678 one",
 		"token=ghp_" + strings.Repeat("X", 40),
-		"Authorization: Bearer abc-123",
+		// Bearer fixture is 30 chars after `Bearer ` so it actually
+		// triggers the `{16,}` minimum and exercises the bearer
+		// redaction's idempotence (a sub-cap bearer like
+		// "Bearer abc-123" would skip the pattern entirely and the
+		// idempotence assertion would be vacuous).
+		"Authorization: Bearer abc-123def-456-789-token-here",
+		// Slack matches the `xox([baprs])-[A-Za-z0-9-]{10,}` shape;
+		// pins idempotence of the new capture-group replacement.
+		"slack tok=xoxb-1234567890-abcde-fghij end",
 		"password: hunter2",
 		"key=sk-ant-" + strings.Repeat("a", 40),
 		"jwt=eyJ-TEST-HEADER-PART.eyJ-TEST-PAYLOAD-PART.TEST-SIGNATURE-PART",

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -380,6 +380,13 @@ func TestDefaultPatternsReturnsDefensiveCopy(t *testing.T) {
 	// permanently change the package default — accidental append in
 	// an init() somewhere could break sanitisation for all callers,
 	// and concurrent reads against a mutated slice can race.
+	//
+	// The test mutates the aws_access_key pattern (located by name,
+	// not by index) so that adding/reordering patterns in the default
+	// set does not silently weaken this assertion: a future reorder
+	// would otherwise mutate a different pattern entry and the AKIA
+	// sanity-check below would still pass even if defensive copy
+	// were broken.
 	copy1 := redact.DefaultPatterns()
 	copy2 := redact.DefaultPatterns()
 
@@ -391,21 +398,38 @@ func TestDefaultPatternsReturnsDefensiveCopy(t *testing.T) {
 			len(copy1), len(copy2))
 	}
 
-	// Mutate copy1[0] in place. The Pattern struct fields (Name,
-	// Replacement) are value-copied by the make+copy sequence, so
-	// this must not affect copy2 OR the internal default set.
-	original := copy1[0]
-	copy1[0] = redact.Pattern{Name: "MUTATED", Replacement: "MUTATED"}
-
-	if copy2[0].Name != original.Name {
-		t.Errorf("DefaultPatterns returned shared backing slice: copy1 mutation affected copy2 (%q != %q)",
-			copy2[0].Name, original.Name)
+	findByName := func(slice []redact.Pattern, name string) (int, bool) {
+		for i, p := range slice {
+			if p.Name == name {
+				return i, true
+			}
+		}
+		return -1, false
 	}
 
-	// Sanitise must still behave per the pre-mutation default set.
-	// Pick a fixture that exercises the first default pattern
-	// (AKIA) so this catches both backing-array sharing and any
-	// stale-pointer issues.
+	idx1, ok := findByName(copy1, "aws_access_key")
+	if !ok {
+		t.Fatal("aws_access_key pattern not present in DefaultPatterns(); update the test fixture or restore the pattern")
+	}
+
+	// Mutate the located entry in copy1. The Pattern struct fields
+	// are value-copied by the make+copy sequence, so this must not
+	// affect copy2 OR the internal default set.
+	original := copy1[idx1]
+	copy1[idx1] = redact.Pattern{Name: "MUTATED", Replacement: "MUTATED"}
+
+	idx2, ok := findByName(copy2, "aws_access_key")
+	if !ok {
+		t.Fatal("aws_access_key pattern disappeared from copy2; DefaultPatterns calls disagree")
+	}
+	if copy2[idx2].Name != original.Name {
+		t.Errorf("DefaultPatterns returned shared backing slice: copy1 mutation affected copy2 (%q != %q)",
+			copy2[idx2].Name, original.Name)
+	}
+
+	// Sanitise must still behave per the pre-mutation default set —
+	// pin via the AKIA fixture that the internal aws_access_key
+	// pattern survived copy1's mutation.
 	out := redact.Sanitise("planted AKIATESTKEY012345678 here")
 	if !strings.Contains(out, "AKIA…REDACTED") {
 		t.Errorf("Sanitise was disturbed by DefaultPatterns copy mutation: %q", out)

--- a/internal/tools/redact/redact_test.go
+++ b/internal/tools/redact/redact_test.go
@@ -157,7 +157,7 @@ func TestSanitisePerPatternPositiveAndNegative(t *testing.T) {
 			name:        "slack_token_xoxb",
 			positive:    "tok=xoxb-1234567890-abcde-fghijk end",
 			negative:    "tok=xoxq-not-a-slack-shape end",
-			mustContain: "xox-…REDACTED",
+			mustContain: "xoxb-…REDACTED",
 		},
 		{
 			name:        "jwt",
@@ -190,7 +190,7 @@ func TestSanitisePerPatternPositiveAndNegative(t *testing.T) {
 			name:        "password_assignment_equals",
 			positive:    "DATABASE_PASSWORD=p@ssw0rd-1!",
 			negative:    "passwordy text",
-			mustContain: "password: REDACTED",
+			mustContain: "PASSWORD=REDACTED",
 		},
 	}
 


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's notes

Chips reads GitHub issues and PRs — including the long, untrusted comment threads on them — and pipes the raw output straight to Claude. Anyone with write access to a watched issue can plant a token-shaped string in a comment and watch it surface in the LLM context. Maren already has redaction at her output boundary; Chips needs the same defence. This PR builds the shared sanitiser primitive both crew (and the orchestrator floor in #129) will consume, wires it into Chips' existing `sanitiseOutput` helper, and ships per-pattern, idempotence, truncation, fail-closed, and attribution-logging test coverage.

The initial structure was two commits — `security(redact)` for the shared package and `security(chips)` for the wiring — and the branch has since grown to a sequence of focused review-cycle fixes (Copilot rounds 1–9). The shape is unchanged: a foundation primitive in `redact`, a chips wrapper that delegates, and an output-boundary chain in every `gh_*` / `git_*` tool.

## Acceptance criteria

Walking #83's AC against this PR:

| AC item | Status |
|---|---|
| Shared sanitiser package at `internal/tools/redact/redact.go` exposes `Sanitise(input string) string` + `MaxSanitiserInputBytes = 65536` ceiling | ✅ |
| Orchestrator-level enforcement seam (#129) consumes this package | Out of scope here; implemented in #129 |
| Input-length ceiling truncates before pattern matching | ✅ + unit-tested |
| Fail-closed contract via `defer recover()` returning `[SANITISER ERROR — content suppressed]` + `slog.Error` | ✅ + unit-tested via nil-regex panic; recover line now also carries caller-supplied attribution attrs (tool/field) for triage |
| Idempotence: `Sanitise(Sanitise(x)) == Sanitise(x)` | ✅ + unit-tested over 10 inputs (redact) + 6 inputs (chips wrapper), including bearer and slack fixtures that actually trigger the patterns |
| `internal/tools/chips/sanitise.go` typed slice + delegates shared | ✅ — slice present as extension point; shared patterns cover Chips' current threat model |
| All `gh_*` tools call the sanitiser on outbound content fields | ✅ — chain happens inside `sanitiseOutput` which every tool already calls. Implementation runs over the whole `gh --json` stdout rather than field-walking specific keys; see "Design notes" #5 for the deviation rationale |
| Per-pattern unit tests (positive + negative) | ✅ in `redact_test.go` (per-pattern positive + near-miss negative across all 9 patterns) + ✅ in `chips/sanitise_test.go` (table-driven per-pattern positive AND negative via `chips.Sanitise`; plus 5 innocent-text preservation cases) |
| Redacted output preserves structure (e.g. `Bearer REDACTED` not blank) | ✅ |
| Sanitisation logs at `slog.Info` with `tool`, `field`, `pattern_name` | ✅ — `redact.Sanitise` / `redact.SanitiseWith` accept variadic `slog.Attr`; `chips.sanitiseOutput` threads `tool=t.Name()` and `field=output` from each `gh_*` / `git_*` caller; one log line per matched pattern with `pattern_name` + `count`. Tests assert raw token values never leak into log output. Routed via a swappable `redact.SetLogger` so test capture and operator routing both avoid mutating `slog.Default` |
| `bridge_tool_redactions_total{tool, pattern}` metric (if #89 landed) | #89 unmerged; gated per AC's own conditional |
| `go test -tags goolm -count=1 ./internal/tools/chips/...` passes | ✅ |

## Design notes worth review

1. **Idempotence is load-bearing for #129.** Replacements use U+2026 (`…`) to break the originating regex character classes — `ghp_…REDACTED` does not re-match `(ghp|...)_[A-Za-z0-9]{36,}` because `…` is multi-byte and outside the ASCII letter/digit class. For `Bearer REDACTED` / `${1}REDACTED`, re-application produces the same string (idempotent by fixed-point).

2. **Bearer pattern tightened from issue text.** Issue body: `(?i)bearer\s+[A-Za-z0-9._\-]+`. Implemented: `[A-Za-z0-9._\-]{16,}`. The `+` form caught the English phrase "the bearer of bad news" as a positive match in local testing; `{16,}` rejects English follow-ons while catching real OAuth/JWT tokens (universally 20+ chars). Documented inline in `redact.go`.

3. **Byte-level truncation at `MaxSanitiserInputBytes = 65536` (64 KiB)**, with `strings.Clone` after both the input cap and the output cap so the truncated string carries its own allocation rather than retaining the original full backing.

4. **`sanitiseOutput` chain order**: substring redaction first (cheap, always-correct for known secrets), pattern matching second (regex pass under length cap). Preserves the #152 contract that known tokens always become `[REDACTED]`, then catches additional planted shapes via the new pattern layer.

5. **Whole-output sanitisation vs field-walking** (AC body says "Touch only the *content* fields ... never structural fields"). Implementation runs the chain over the whole `gh --json` stdout rather than `json.Unmarshal` + per-field walk. The patterns are narrow enough that numbers, dates, and non-token-bearing URLs aren't matched in practice; the one edge case where the deviation matters (a URL query string containing `?password=...`) produces desirable redaction of a secret-in-URL leak. Per-field walking was deemed unnecessary complexity because the orchestrator-level safety floor in #129 will whole-output-sanitise downstream anyway. Pinned in an inline comment on `sanitiseOutput`.

6. **Attribution-logging hot path is single-pass.** `ReplaceAllStringFunc` counts via the closure and re-applies the pattern to each match for capture-group expansion (`${1}_…REDACTED` etc.). Total cost is `O(|input|) + O(Σ|match|)` rather than `2 × O(|input|)` that a separate `FindAll + Replace` would pay. The no-attrs hot path (orchestrator floor) is unchanged: a single `ReplaceAllString` call, no closure overhead.

7. **`redact.SetLogger`** exposes a swappable logger for both test capture and production routing. Tests install a buffer-backed logger via the API and never touch `slog.Default`. `SetLogger(nil)` resets to default to avoid a nil-deref-in-recover failure mode.

## Test plan

- [x] CI green on `test`, `license-audit`, `docker`, `lint-workflows`, `skills-drift`, `coverage-gate`
- [x] Local `go vet -tags goolm ./internal/tools/redact/... ./internal/tools/chips/...` clean
- [x] Local `go test -tags goolm -count=1 ./internal/...` — all 14 internal packages green (no regression)
- [x] `internal/tools/redact` package coverage: 100% of statements
- [x] `internal/tools/chips/sanitise.go`, `chips.Sanitise`, and the `sanitiseOutput` chain: 100% per `go tool cover -func`
- [ ] Manual smoke after deploy: a chips tool reading an issue body that contains a planted `ghp_AAAA…AAAA` shape returns output where the raw token is replaced with `ghp_…REDACTED` AND a `sanitiser_redaction` log line appears in Loki tagged `tool=gh_issue_view field=output pattern_name=github_token count=1`

## Out of scope / follow-up

- **#129 orchestrator-level safety floor** — separate PR; consumes this package as the safety floor over every `tool_result`
- **#84 Crest email-preview sanitisation** — separate PR; extends the shared package with email-specific patterns
- **#85 Maren K8s manifest redaction key set** — separate PR

Closes #83
Refs #129
