### PR TITLE
security(orchestrator): enforce sanitiser at tool_result intake 🔐

### DIFF
--- a/internal/orchestrator/sanitise.go
+++ b/internal/orchestrator/sanitise.go
@@ -20,9 +20,9 @@ import (
 // means the per-tool layer either missed the shape or never ran (a
 // new tool author or a third-party tool integration that bypassed
 // the chips-style helper). In steady state with per-tool sanitisers
-// doing their job, this layer emits nothing — content reaching it is
-// already redacted, so FindAllStringIndex returns zero matches and
-// no slog line fires.
+// (and the orchestrator's pre-sanitise pass on path 1/2/3 error
+// strings) doing their job, this layer finds zero matches in its
+// input and emits nothing.
 //
 // Inherits the fail-closed, byte-cap, and clone-on-truncate contracts
 // from redact.SanitiseWith.

--- a/internal/orchestrator/sanitise.go
+++ b/internal/orchestrator/sanitise.go
@@ -1,0 +1,43 @@
+package orchestrator
+
+import (
+	"log/slog"
+
+	"klazomenai/bridge/internal/tools/redact"
+)
+
+// sanitiseToolResultContent applies the shared redact.Sanitise pass
+// to a tool_result content string before it joins the message history
+// sent to Claude. This is the orchestrator-level safety floor
+// described in #129: per-tool sanitisers (chips, maren, crest) stay
+// as the first line of defence; this layer guarantees that every
+// tool_result reaching the model has passed through the shared
+// pattern set, regardless of whether the per-tool layer remembered
+// to sanitise.
+//
+// Emits with layer="orchestrator_floor" so operators can grep floor-
+// level catches distinct from per-tool emissions: a floor emission
+// means the per-tool layer either missed the shape or never ran (a
+// new tool author or a third-party tool integration that bypassed
+// the chips-style helper). In steady state with per-tool sanitisers
+// doing their job, this layer emits nothing — content reaching it is
+// already redacted, so FindAllStringIndex returns zero matches and
+// no slog line fires.
+//
+// Inherits the fail-closed, byte-cap, and clone-on-truncate contracts
+// from redact.SanitiseWith.
+func sanitiseToolResultContent(toolName, content string) string {
+	return redact.Sanitise(content,
+		slog.String("layer", "orchestrator_floor"),
+		slog.String("tool", toolName),
+		slog.String("field", "tool_result"),
+	)
+}
+
+// SanitiseToolResultContentForTest is an exported alias for testing.
+// Test code in package orchestrator_test uses it to drive the
+// floor's idempotence, length-ceiling, and fail-closed behaviour
+// directly without setting up the full orchestrator pipeline. Do
+// NOT call from production code — use the orchestrator's tool-use
+// loop instead.
+var SanitiseToolResultContentForTest = sanitiseToolResultContent

--- a/internal/orchestrator/sanitise.go
+++ b/internal/orchestrator/sanitise.go
@@ -27,9 +27,22 @@ import (
 // Inherits the fail-closed, byte-cap, and clone-on-truncate contracts
 // from redact.SanitiseWith.
 func sanitiseToolResultContent(toolName, content string) string {
+	// The tool name on the allowlist-refusal and unknown-tool paths
+	// is model-supplied (block.Name from Claude's tool_use response)
+	// and is NOT validated against any registry — Claude can return
+	// any string as a tool name, including a token-shaped value. If
+	// the raw name were used as the slog `tool` attribute, the floor
+	// would redact the leak from the tool_result content but
+	// reintroduce it in its own attribution log. Apply Sanitise to
+	// the name first; for legitimate registered tool names
+	// (delegate_to_crew, gh_issue_view, ...) this is a no-op because
+	// no default pattern matches a typical tool name. The outer
+	// Sanitise on the content does the actual content redaction
+	// AND emits the slog line with the now-safe name attribute.
+	safeToolAttr := redact.Sanitise(toolName)
 	return redact.Sanitise(content,
 		slog.String("layer", "orchestrator_floor"),
-		slog.String("tool", toolName),
+		slog.String("tool", safeToolAttr),
 		slog.String("field", "tool_result"),
 	)
 }

--- a/internal/orchestrator/sanitise_test.go
+++ b/internal/orchestrator/sanitise_test.go
@@ -295,8 +295,18 @@ crew:
 	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
 		t.Errorf("expected layer=orchestrator_floor in log, got: %s", logOut)
 	}
-	if !strings.Contains(logOut, `"tool":"`+leakyToolName+`"`) {
-		t.Errorf("expected tool=%s in log, got: %s", leakyToolName, logOut)
+	// The `tool` slog attribute is itself Sanitise'd before emission
+	// — block.Name on this path is model-supplied and could itself
+	// be a token shape, so the raw name MUST NOT surface in the
+	// floor's own attribution log even though the content was
+	// redacted (Copilot-flagged regression: without this sanitise,
+	// the floor would leak in the log what it just redacted from the
+	// tool_result content).
+	if strings.Contains(logOut, leakyToolName) {
+		t.Errorf("raw tool-name token surfaced in floor's own slog attribution: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"tool":"AKIA…REDACTED"`) {
+		t.Errorf("expected tool=AKIA…REDACTED in log (sanitised form), got: %s", logOut)
 	}
 
 	// (2) Tool-result content sent back to Claude carries the
@@ -373,8 +383,14 @@ crew:
 	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
 		t.Errorf("expected layer=orchestrator_floor, got: %s", logOut)
 	}
-	if !strings.Contains(logOut, `"tool":"`+leakyToolName+`"`) {
-		t.Errorf("expected tool=%s, got: %s", leakyToolName, logOut)
+	// Same regression check as the allowlist-refusal path: the
+	// model-supplied tool name MUST NOT appear in the floor's
+	// attribution log; the `tool` attr is Sanitise'd first.
+	if strings.Contains(logOut, leakyToolName) {
+		t.Errorf("raw tool-name token surfaced in floor's own slog attribution: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"tool":"AKIA…REDACTED"`) {
+		t.Errorf("expected tool=AKIA…REDACTED (sanitised), got: %s", logOut)
 	}
 
 	content := extractToolResultText(t, mock)

--- a/internal/orchestrator/sanitise_test.go
+++ b/internal/orchestrator/sanitise_test.go
@@ -157,39 +157,41 @@ func extractToolResultText(t *testing.T, mock *mockClaudeClient) string {
 // content block routed through the orchestrator passes through the
 // shared redact.Sanitise, regardless of whether the producing tool
 // already sanitised its own output. The table covers a single-
-// pattern case per default pattern shape PLUS a multi-pattern case,
-// so a tool whose output bypasses the per-tool layer (new author,
-// third-party integration) still has the floor as a backstop.
+// pattern case per default pattern shape PLUS a multi-pattern case
+// whose expectations are slices of strings so every planted token
+// shape is verified individually — a regression that stopped
+// sanitisation after the first pattern would otherwise sneak
+// through a single-expectation assertion on the multi-pattern case.
 func TestOrchestrator_AllToolResultsPassThroughSanitiser(t *testing.T) {
 	cases := []struct {
 		name        string
 		output      string
-		mustNotHave string
-		mustContain string
+		mustNotHave []string
+		mustContain []string
 	}{
 		{
 			name:        "aws_access_key",
 			output:      "comment: AKIATESTKEY012345678 planted by attacker",
-			mustNotHave: "AKIATESTKEY012345678",
-			mustContain: "AKIA…REDACTED",
+			mustNotHave: []string{"AKIATESTKEY012345678"},
+			mustContain: []string{"AKIA…REDACTED"},
 		},
 		{
 			name:        "github_token",
 			output:      "PAT leaked: ghp_" + strings.Repeat("A", 40) + " end",
-			mustNotHave: strings.Repeat("A", 40),
-			mustContain: "ghp_…REDACTED",
+			mustNotHave: []string{strings.Repeat("A", 40)},
+			mustContain: []string{"ghp_…REDACTED"},
 		},
 		{
 			name:        "openai_anthropic_key",
 			output:      "claude key sk-ant-" + strings.Repeat("d", 40) + " in body",
-			mustNotHave: strings.Repeat("d", 40),
-			mustContain: "sk-…REDACTED",
+			mustNotHave: []string{strings.Repeat("d", 40)},
+			mustContain: []string{"sk-…REDACTED"},
 		},
 		{
 			name:        "multi_pattern_payload",
 			output:      "AWS=AKIATESTKEY012345678 GH=ghp_" + strings.Repeat("B", 40),
-			mustNotHave: "AKIATESTKEY012345678",
-			mustContain: "AKIA…REDACTED",
+			mustNotHave: []string{"AKIATESTKEY012345678", strings.Repeat("B", 40)},
+			mustContain: []string{"AKIA…REDACTED", "ghp_…REDACTED"},
 		},
 	}
 	for _, tc := range cases {
@@ -207,12 +209,17 @@ func TestOrchestrator_AllToolResultsPassThroughSanitiser(t *testing.T) {
 				t.Fatalf("Handle: %v", err)
 			}
 			content := extractToolResultText(t, mock)
-			if strings.Contains(content, tc.mustNotHave) {
-				t.Errorf("raw token leaked through orchestrator floor: %q", content)
+			for _, raw := range tc.mustNotHave {
+				if strings.Contains(content, raw) {
+					t.Errorf("raw token %q leaked through orchestrator floor: %q",
+						raw, content)
+				}
 			}
-			if !strings.Contains(content, tc.mustContain) {
-				t.Errorf("expected %q in tool_result content, got: %q",
-					tc.mustContain, content)
+			for _, sentinel := range tc.mustContain {
+				if !strings.Contains(content, sentinel) {
+					t.Errorf("expected %q in tool_result content, got: %q",
+						sentinel, content)
+				}
 			}
 		})
 	}

--- a/internal/orchestrator/sanitise_test.go
+++ b/internal/orchestrator/sanitise_test.go
@@ -1,6 +1,7 @@
 package orchestrator_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,6 +19,23 @@ import (
 	"klazomenai/bridge/internal/tools"
 	"klazomenai/bridge/internal/tools/redact"
 )
+
+// captureSlogForOrch routes redact's "sanitiser_redaction" emissions
+// to a buffer via redact.SetLogger so per-call-site tests can prove
+// the orchestrator floor actually invoked the helper at each
+// NewToolResultBlock site. The orchestrator's own slog calls go to
+// slog.Default and are NOT captured here — the buffer holds only
+// floor emissions plus any panic-recovery line, keeping assertions
+// scoped.
+func captureSlogForOrch(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	restore := redact.SetLogger(logger)
+	return &buf, restore
+}
 
 // configurableOutputTool returns a fixed string regardless of input.
 // Used by sanitiser-floor tests that need specific output shapes
@@ -211,6 +229,221 @@ func TestOrchestrator_SanitiseLengthCeilingAtBoundary(t *testing.T) {
 	if len(out) > redact.MaxSanitiserInputBytes {
 		t.Errorf("orchestrator floor did not truncate oversized input: got %d bytes, cap %d",
 			len(out), redact.MaxSanitiserInputBytes)
+	}
+}
+
+// TestOrchestrator_FloorAppliedToAllowlistRefusalPath pins that the
+// "tool not in crew allowlist" branch (the first NewToolResultBlock
+// site in executeToolCalls) also runs through sanitiseToolResultContent.
+// Constructed by having Claude request a tool whose Name is itself a
+// token-shape string: the orchestrator-built error message
+// `tool "AKIATESTKEY012345678" not allowed for this crew member`
+// contains an AWS-shape literal, so the floor matches, redacts, and
+// emits a `sanitiser_redaction` line tagged with that tool name. The
+// assertions cover both the visible-content side (tool_result sent to
+// Claude carries the sentinel, not the raw token) and the floor-
+// emission side (the slog line proves the helper actually fired at
+// this call site, not just that the code path doesn't crash).
+func TestOrchestrator_FloorAppliedToAllowlistRefusalPath(t *testing.T) {
+	buf, restore := captureSlogForOrch(t)
+	defer restore()
+
+	const leakyToolName = "AKIATESTKEY012345678"
+	leakyTool := &configurableOutputTool{name: leakyToolName, output: "irrelevant"}
+
+	// Maren's allowlist is [delegate_to_crew] only — leakyToolName
+	// is registered but NOT authorised, so path 1 fires.
+	crewYAML := `
+default_crew: maren
+crew:
+  maren:
+    name: "Maren"
+    role: "Shipwright"
+    model: "claude-sonnet-4-6"
+    verbosity: dispatch
+    tools: [delegate_to_crew]
+    voice:
+      model: "en_GB-cori-high.onnx"
+      announces_as: "Maren:"
+    system_prompt: "You are Maren. Respond in {verbosity}"
+`
+	f := filepath.Join(t.TempDir(), "crew.yaml")
+	if err := os.WriteFile(f, []byte(crewYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := crew.Load(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolReg := newToolRegistry(leakyTool)
+	mgr := ctxbuf.NewManager(ctxbuf.DefaultMaxTurns)
+	mock := &mockClaudeClient{responses: []*anthropic.Message{
+		toolUseResponse("tu_1", leakyToolName, json.RawMessage(`{}`)),
+		textResponse("Got the error."),
+	}}
+	o := orchestrator.NewWithClient(reg, mgr, toolReg, mock)
+
+	if _, err := o.Handle(t.Context(), "!room:server", "try leaky", "maren"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	// (1) Floor emission proves the helper ran at the allowlist-refusal site.
+	logOut := buf.String()
+	if !strings.Contains(logOut, `"msg":"sanitiser_redaction"`) {
+		t.Errorf("expected floor emission in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
+		t.Errorf("expected layer=orchestrator_floor in log, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"tool":"`+leakyToolName+`"`) {
+		t.Errorf("expected tool=%s in log, got: %s", leakyToolName, logOut)
+	}
+
+	// (2) Tool-result content sent back to Claude carries the
+	//     sentinel, not the raw token.
+	content := extractToolResultText(t, mock)
+	if strings.Contains(content, leakyToolName) {
+		t.Errorf("raw tool-name token surfaced in tool_result: %q", content)
+	}
+	if !strings.Contains(content, "AKIA…REDACTED") {
+		t.Errorf("expected AKIA…REDACTED in tool_result, got: %q", content)
+	}
+	// And isError=true is preserved (the floor doesn't touch the
+	// error flag, only the content string).
+	secondCall := mock.calls[1]
+	tr := secondCall.Messages[len(secondCall.Messages)-1].Content[0].OfToolResult
+	if !tr.IsError.Value {
+		t.Error("expected isError=true on allowlist-refusal result")
+	}
+}
+
+// TestOrchestrator_FloorAppliedToUnknownToolPath pins that the
+// "unknown tool" branch (the second NewToolResultBlock site)
+// constructs its error message through sanitiseToolResultContent.
+// Setup: the crew's allowlist DECLARES a token-shape tool name, but
+// that tool is NOT registered — so the allowlist check passes and
+// the registry lookup fails, hitting path 2. The constructed error
+// `tool error: unknown tool: "AKIATESTKEY012345678"` contains the
+// AWS-shape literal which the floor redacts.
+func TestOrchestrator_FloorAppliedToUnknownToolPath(t *testing.T) {
+	buf, restore := captureSlogForOrch(t)
+	defer restore()
+
+	const leakyToolName = "AKIATESTKEY012345678"
+
+	crewYAML := fmt.Sprintf(`
+default_crew: maren
+crew:
+  maren:
+    name: "Maren"
+    role: "Shipwright"
+    model: "claude-sonnet-4-6"
+    verbosity: dispatch
+    tools: [%s]
+    voice:
+      model: "en_GB-cori-high.onnx"
+      announces_as: "Maren:"
+    system_prompt: "You are Maren. Respond in {verbosity}"
+`, leakyToolName)
+	f := filepath.Join(t.TempDir(), "crew.yaml")
+	if err := os.WriteFile(f, []byte(crewYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := crew.Load(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Empty tool registry — the named tool is allowlisted but not registered.
+	toolReg := newToolRegistry()
+	mgr := ctxbuf.NewManager(ctxbuf.DefaultMaxTurns)
+	mock := &mockClaudeClient{responses: []*anthropic.Message{
+		toolUseResponse("tu_1", leakyToolName, json.RawMessage(`{}`)),
+		textResponse("Got the unknown-tool error."),
+	}}
+	o := orchestrator.NewWithClient(reg, mgr, toolReg, mock)
+
+	if _, err := o.Handle(t.Context(), "!room:server", "try ghost", "maren"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	logOut := buf.String()
+	if !strings.Contains(logOut, `"msg":"sanitiser_redaction"`) {
+		t.Errorf("expected floor emission, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
+		t.Errorf("expected layer=orchestrator_floor, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"tool":"`+leakyToolName+`"`) {
+		t.Errorf("expected tool=%s, got: %s", leakyToolName, logOut)
+	}
+
+	content := extractToolResultText(t, mock)
+	if strings.Contains(content, leakyToolName) {
+		t.Errorf("raw tool-name token surfaced: %q", content)
+	}
+	if !strings.Contains(content, "AKIA…REDACTED") {
+		t.Errorf("expected AKIA…REDACTED, got: %q", content)
+	}
+	secondCall := mock.calls[1]
+	tr := secondCall.Messages[len(secondCall.Messages)-1].Content[0].OfToolResult
+	if !tr.IsError.Value {
+		t.Error("expected isError=true on unknown-tool result")
+	}
+}
+
+// TestOrchestrator_FloorAppliedToDelegationSentinelPath pins that
+// the "Delegating to ..." sentinel string (the third
+// NewToolResultBlock site) also passes through
+// sanitiseToolResultContent. The delegation path returns early from
+// runToolLoop without making a second API call (the loopResult's
+// turns hold the tool_result locally until the delegated crew runs),
+// so the proof of the floor having executed is the slog emission —
+// captured via redact.SetLogger.
+//
+// Setup: Maren's delegate_to_crew tool emits a sentinel pointing to
+// a target crew named with a github_token shape. DelegateTool.Execute
+// applies strings.ToLower to the crew name (line 55 of delegate.go)
+// which rules out the case-sensitive AWS pattern; github_token is
+// case-sensitive on the `ghp_` prefix but lowercase by default, so
+// the post-lowercasing form still matches. The unknown target crew
+// falls back to default routing (mirroring TestDelegationToUnknownCrewFallsToDefault).
+func TestOrchestrator_FloorAppliedToDelegationSentinelPath(t *testing.T) {
+	buf, restore := captureSlogForOrch(t)
+	defer restore()
+
+	// 44-char fixture: ghp_ + 40 lowercase chars. Survives ToLower,
+	// matches the github_token pattern's {36,} minimum.
+	leakyCrew := "ghp_" + strings.Repeat("a", 40)
+	delegateInput := json.RawMessage(fmt.Sprintf(`{"crew":"%s","context":"go"}`, leakyCrew))
+
+	// Maren delegates to the token-shape crew (unknown → falls back).
+	toolReg := newToolRegistry(&echoTool{})
+	o, _ := newTestOrchestrator(t, toolReg,
+		toolUseWithTextResponse("delegating", "tu_1", "delegate_to_crew", delegateInput),
+		textResponse("got it"), // fallback default-crew response
+	)
+
+	if _, err := o.Handle(t.Context(), "!room:server", "try delegate", "maren"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	logOut := buf.String()
+	if !strings.Contains(logOut, `"msg":"sanitiser_redaction"`) {
+		t.Errorf("expected floor emission for delegation path, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
+		t.Errorf("expected layer=orchestrator_floor, got: %s", logOut)
+	}
+	// The block.Name for delegation is delegate_to_crew, NOT the target
+	// crew. That's the orchestrator's invariant — the floor's tool
+	// attribution identifies which tool produced the tool_result, not
+	// which crew was being delegated to.
+	if !strings.Contains(logOut, `"tool":"delegate_to_crew"`) {
+		t.Errorf("expected tool=delegate_to_crew, got: %s", logOut)
+	}
+	// And the github_token pattern from the leaky crew name fired.
+	if !strings.Contains(logOut, `"pattern_name":"github_token"`) {
+		t.Errorf("expected pattern_name=github_token, got: %s", logOut)
 	}
 }
 

--- a/internal/orchestrator/sanitise_test.go
+++ b/internal/orchestrator/sanitise_test.go
@@ -20,21 +20,37 @@ import (
 	"klazomenai/bridge/internal/tools/redact"
 )
 
-// captureSlogForOrch routes redact's "sanitiser_redaction" emissions
-// to a buffer via redact.SetLogger so per-call-site tests can prove
-// the orchestrator floor actually invoked the helper at each
-// NewToolResultBlock site. The orchestrator's own slog calls go to
-// slog.Default and are NOT captured here — the buffer holds only
-// floor emissions plus any panic-recovery line, keeping assertions
-// scoped.
+// captureSlogForOrch routes BOTH redact's "sanitiser_redaction"
+// emissions (via redact.SetLogger) AND the orchestrator's own
+// slog.Default emissions to a single JSON buffer. Tests inspect
+// both surfaces:
+//
+//   - redact's floor emissions prove (or rule out) the floor fired.
+//   - the orchestrator's own Warn/Info emissions are where
+//     model-supplied identifiers (tool names, target crews) reach
+//     log infrastructure. The path-1 / path-2 / path-3 tests assert
+//     no raw token leaks via either surface.
+//
+// slog.SetDefault is process-global. Within a Go test binary the
+// tests run sequentially (no t.Parallel() in this file), and the
+// deferred restore unwinds the mutation; the slog.SetDefault hazard
+// Copilot flagged in #170 round-8 was a cross-package concern that
+// doesn't apply here since each go-test package binary is its own
+// process. The redact side still uses redact.SetLogger, so the same
+// principle holds: package-local, sequential, defer-restored.
 func captureSlogForOrch(t *testing.T) (*bytes.Buffer, func()) {
 	t.Helper()
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
-	restore := redact.SetLogger(logger)
-	return &buf, restore
+	restoreRedact := redact.SetLogger(logger)
+	originalDefault := slog.Default()
+	slog.SetDefault(logger)
+	return &buf, func() {
+		slog.SetDefault(originalDefault)
+		restoreRedact()
+	}
 }
 
 // configurableOutputTool returns a fixed string regardless of input.
@@ -287,30 +303,25 @@ crew:
 		t.Fatalf("Handle: %v", err)
 	}
 
-	// (1) Floor emission proves the helper ran at the allowlist-refusal site.
+	// (1) The orchestrator's OWN "tool not in crew allowlist" Warn
+	//     line must NOT contain the raw model-supplied tool name.
+	//     The orchestrator pre-sanitises block.Name once at the top
+	//     of this branch and reuses the sanitised form for both the
+	//     Warn log and the tool_result content; the raw token shape
+	//     is therefore never given to a logging surface.
 	logOut := buf.String()
-	if !strings.Contains(logOut, `"msg":"sanitiser_redaction"`) {
-		t.Errorf("expected floor emission in log, got: %s", logOut)
-	}
-	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
-		t.Errorf("expected layer=orchestrator_floor in log, got: %s", logOut)
-	}
-	// The `tool` slog attribute is itself Sanitise'd before emission
-	// — block.Name on this path is model-supplied and could itself
-	// be a token shape, so the raw name MUST NOT surface in the
-	// floor's own attribution log even though the content was
-	// redacted (Copilot-flagged regression: without this sanitise,
-	// the floor would leak in the log what it just redacted from the
-	// tool_result content).
 	if strings.Contains(logOut, leakyToolName) {
-		t.Errorf("raw tool-name token surfaced in floor's own slog attribution: %s", logOut)
+		t.Errorf("raw tool-name token surfaced in slog output: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"msg":"orchestrator: tool not in crew allowlist"`) {
+		t.Errorf("expected orchestrator allowlist Warn line, got: %s", logOut)
 	}
 	if !strings.Contains(logOut, `"tool":"AKIA…REDACTED"`) {
-		t.Errorf("expected tool=AKIA…REDACTED in log (sanitised form), got: %s", logOut)
+		t.Errorf("expected sanitised tool name in slog, got: %s", logOut)
 	}
 
-	// (2) Tool-result content sent back to Claude carries the
-	//     sentinel, not the raw token.
+	// (2) The tool_result content sent back to Claude also carries
+	//     the sanitised form (same pre-sanitisation, same name).
 	content := extractToolResultText(t, mock)
 	if strings.Contains(content, leakyToolName) {
 		t.Errorf("raw tool-name token surfaced in tool_result: %q", content)
@@ -318,8 +329,8 @@ crew:
 	if !strings.Contains(content, "AKIA…REDACTED") {
 		t.Errorf("expected AKIA…REDACTED in tool_result, got: %q", content)
 	}
-	// And isError=true is preserved (the floor doesn't touch the
-	// error flag, only the content string).
+	// isError=true preserved (pre-sanitisation only touches the name
+	// string; the error flag is untouched).
 	secondCall := mock.calls[1]
 	tr := secondCall.Messages[len(secondCall.Messages)-1].Content[0].OfToolResult
 	if !tr.IsError.Value {
@@ -376,21 +387,20 @@ crew:
 		t.Fatalf("Handle: %v", err)
 	}
 
-	logOut := buf.String()
-	if !strings.Contains(logOut, `"msg":"sanitiser_redaction"`) {
-		t.Errorf("expected floor emission, got: %s", logOut)
-	}
-	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
-		t.Errorf("expected layer=orchestrator_floor, got: %s", logOut)
-	}
 	// Same regression check as the allowlist-refusal path: the
-	// model-supplied tool name MUST NOT appear in the floor's
-	// attribution log; the `tool` attr is Sanitise'd first.
+	// model-supplied tool name MUST NOT appear in the orchestrator's
+	// own "unknown tool requested" Warn log; block.Name is pre-
+	// sanitised once and reused for both the Warn log and the
+	// tool_result content.
+	logOut := buf.String()
 	if strings.Contains(logOut, leakyToolName) {
-		t.Errorf("raw tool-name token surfaced in floor's own slog attribution: %s", logOut)
+		t.Errorf("raw tool-name token surfaced in slog output: %s", logOut)
+	}
+	if !strings.Contains(logOut, `"msg":"orchestrator: unknown tool requested"`) {
+		t.Errorf("expected orchestrator unknown-tool Warn line, got: %s", logOut)
 	}
 	if !strings.Contains(logOut, `"tool":"AKIA…REDACTED"`) {
-		t.Errorf("expected tool=AKIA…REDACTED (sanitised), got: %s", logOut)
+		t.Errorf("expected sanitised tool name in slog, got: %s", logOut)
 	}
 
 	content := extractToolResultText(t, mock)
@@ -443,23 +453,36 @@ func TestOrchestrator_FloorAppliedToDelegationSentinelPath(t *testing.T) {
 		t.Fatalf("Handle: %v", err)
 	}
 
+	// The orchestrator's "delegation requested" slog.Info line
+	// receives the pre-sanitised target crew name (the same
+	// safeTarget is also used in the tool_result construction). The
+	// raw model-supplied targetCrew must not appear in this line.
+	//
+	// Note: orchestrator.go's downstream "following delegation" and
+	// "unknown crew member, falling back to default" lines still log
+	// the raw targetCrew — those are outside #129's scope and
+	// tracked as follow-up work. The buffer here may legitimately
+	// contain the raw form on those lines; the assertion is
+	// specifically scoped to the toolloop.go "delegation requested"
+	// emission.
 	logOut := buf.String()
-	if !strings.Contains(logOut, `"msg":"sanitiser_redaction"`) {
-		t.Errorf("expected floor emission for delegation path, got: %s", logOut)
+	if !strings.Contains(logOut, `"msg":"orchestrator: delegation requested"`) {
+		t.Errorf("expected orchestrator delegation Info line, got: %s", logOut)
 	}
-	if !strings.Contains(logOut, `"layer":"orchestrator_floor"`) {
-		t.Errorf("expected layer=orchestrator_floor, got: %s", logOut)
-	}
-	// The block.Name for delegation is delegate_to_crew, NOT the target
-	// crew. That's the orchestrator's invariant — the floor's tool
-	// attribution identifies which tool produced the tool_result, not
-	// which crew was being delegated to.
-	if !strings.Contains(logOut, `"tool":"delegate_to_crew"`) {
-		t.Errorf("expected tool=delegate_to_crew, got: %s", logOut)
-	}
-	// And the github_token pattern from the leaky crew name fired.
-	if !strings.Contains(logOut, `"pattern_name":"github_token"`) {
-		t.Errorf("expected pattern_name=github_token, got: %s", logOut)
+	// Scope: find the "delegation requested" line specifically and
+	// check it. Using simple JSON-as-text containment with both
+	// `msg` and `to` in the same line slice.
+	for _, line := range strings.Split(logOut, "\n") {
+		if !strings.Contains(line, `"msg":"orchestrator: delegation requested"`) {
+			continue
+		}
+		if strings.Contains(line, leakyCrew) {
+			t.Errorf("raw target-crew token surfaced in delegation-requested line: %s", line)
+		}
+		if !strings.Contains(line, `"to":"ghp_…REDACTED"`) {
+			t.Errorf("expected to=ghp_…REDACTED (sanitised) in delegation-requested line, got: %s", line)
+		}
+		break
 	}
 }
 

--- a/internal/orchestrator/sanitise_test.go
+++ b/internal/orchestrator/sanitise_test.go
@@ -250,16 +250,15 @@ func TestOrchestrator_SanitiseLengthCeilingAtBoundary(t *testing.T) {
 
 // TestOrchestrator_FloorAppliedToAllowlistRefusalPath pins that the
 // "tool not in crew allowlist" branch (the first NewToolResultBlock
-// site in executeToolCalls) also runs through sanitiseToolResultContent.
-// Constructed by having Claude request a tool whose Name is itself a
-// token-shape string: the orchestrator-built error message
-// `tool "AKIATESTKEY012345678" not allowed for this crew member`
-// contains an AWS-shape literal, so the floor matches, redacts, and
-// emits a `sanitiser_redaction` line tagged with that tool name. The
-// assertions cover both the visible-content side (tool_result sent to
-// Claude carries the sentinel, not the raw token) and the floor-
-// emission side (the slog line proves the helper actually fired at
-// this call site, not just that the code path doesn't crash).
+// site in executeToolCalls) handles a token-shape block.Name
+// without leaking it anywhere. Claude requests a tool whose Name is
+// a token shape (AKIA-pattern); the orchestrator pre-sanitises
+// block.Name once at the branch top and reuses the safe form for
+// both the "tool not in crew allowlist" Warn log AND the
+// tool_result content sent back to Claude. The floor's content scan
+// then finds zero patterns (content already contains AKIA…REDACTED)
+// and stays silent — assertions verify the raw name is absent from
+// the orchestrator's own Warn log AND from the tool_result block.
 func TestOrchestrator_FloorAppliedToAllowlistRefusalPath(t *testing.T) {
 	buf, restore := captureSlogForOrch(t)
 	defer restore()
@@ -339,13 +338,15 @@ crew:
 }
 
 // TestOrchestrator_FloorAppliedToUnknownToolPath pins that the
-// "unknown tool" branch (the second NewToolResultBlock site)
-// constructs its error message through sanitiseToolResultContent.
-// Setup: the crew's allowlist DECLARES a token-shape tool name, but
-// that tool is NOT registered — so the allowlist check passes and
-// the registry lookup fails, hitting path 2. The constructed error
-// `tool error: unknown tool: "AKIATESTKEY012345678"` contains the
-// AWS-shape literal which the floor redacts.
+// "unknown tool" branch (the second NewToolResultBlock site) also
+// handles a token-shape block.Name safely. Setup: the crew's
+// allowlist DECLARES a token-shape tool name, but the registry
+// doesn't have it — so the allowlist check passes and the registry
+// lookup fails, hitting path 2. Same pre-sanitise pattern as path 1:
+// safeName flows into both the Warn log AND the tool_result content,
+// so the raw model-supplied name never reaches either surface. The
+// floor's content scan sees AKIA…REDACTED (already safe) and stays
+// silent; assertions check raw-name absence on both surfaces.
 func TestOrchestrator_FloorAppliedToUnknownToolPath(t *testing.T) {
 	buf, restore := captureSlogForOrch(t)
 	defer restore()

--- a/internal/orchestrator/sanitise_test.go
+++ b/internal/orchestrator/sanitise_test.go
@@ -1,0 +1,245 @@
+package orchestrator_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+
+	ctxbuf "klazomenai/bridge/internal/context"
+	"klazomenai/bridge/internal/crew"
+	"klazomenai/bridge/internal/orchestrator"
+	"klazomenai/bridge/internal/tools"
+	"klazomenai/bridge/internal/tools/redact"
+)
+
+// configurableOutputTool returns a fixed string regardless of input.
+// Used by sanitiser-floor tests that need specific output shapes
+// (planted tokens, multi-pattern payloads) without rewiring a
+// production tool's mock behaviour.
+type configurableOutputTool struct {
+	name   string
+	output string
+}
+
+func (t *configurableOutputTool) Name() string        { return t.name }
+func (t *configurableOutputTool) Description() string { return "test tool returning configurable output" }
+func (t *configurableOutputTool) InputSchema() anthropic.ToolInputSchemaParam {
+	return anthropic.ToolInputSchemaParam{Properties: map[string]any{}}
+}
+func (t *configurableOutputTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
+	return t.output, nil
+}
+
+// panicOnInfoHandler is a test-only slog.Handler that panics when
+// asked to emit at slog.LevelInfo. Used to exercise the orchestrator
+// floor's fail-closed contract: redact.SanitiseWith's per-pattern
+// Info emission panics, the deferred recover catches it, emits the
+// Error line via the same logger (which does NOT panic on Error),
+// and returns SanitiserErrorReplacement. The orchestrator floor
+// passes that replacement straight through to the tool_result.
+type panicOnInfoHandler struct{}
+
+func (h *panicOnInfoHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *panicOnInfoHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelInfo {
+		panic("simulated sanitise handler panic on Info emission")
+	}
+	return nil
+}
+
+func (h *panicOnInfoHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *panicOnInfoHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// sanitiserTestOrchestrator wires up an orchestrator whose crew yaml
+// authorises the supplied test tool, returning the orchestrator and
+// the mock Claude client so callers can inspect what was sent back
+// to the model in the second API call's tool_result block.
+func sanitiserTestOrchestrator(t *testing.T, tool tools.ToolDefinition, responses ...*anthropic.Message) (*orchestrator.Orchestrator, *mockClaudeClient) {
+	t.Helper()
+
+	crewYAML := fmt.Sprintf(`
+default_crew: maren
+crew:
+  maren:
+    name: "Maren"
+    role: "Shipwright"
+    model: "claude-sonnet-4-6"
+    verbosity: dispatch
+    tools: [%s]
+    voice:
+      model: "en_GB-cori-high.onnx"
+      announces_as: "Maren:"
+    system_prompt: "You are Maren. Respond in {verbosity}"
+`, tool.Name())
+	f := filepath.Join(t.TempDir(), "crew.yaml")
+	if err := os.WriteFile(f, []byte(crewYAML), 0o600); err != nil {
+		t.Fatalf("write crew yaml: %v", err)
+	}
+	reg, err := crew.Load(f)
+	if err != nil {
+		t.Fatalf("load crew: %v", err)
+	}
+	toolReg := newToolRegistry(tool)
+	mgr := ctxbuf.NewManager(ctxbuf.DefaultMaxTurns)
+	mock := &mockClaudeClient{responses: responses}
+	o := orchestrator.NewWithClient(reg, mgr, toolReg, mock)
+	return o, mock
+}
+
+// extractToolResultText returns the text content of the tool_result
+// block sent in the second API call (i.e. the result fed back to
+// Claude after the first tool round). Fails the test if no
+// tool_result is present.
+func extractToolResultText(t *testing.T, mock *mockClaudeClient) string {
+	t.Helper()
+	if len(mock.calls) < 2 {
+		t.Fatalf("expected at least 2 API calls, got %d", len(mock.calls))
+	}
+	secondCall := mock.calls[1]
+	if len(secondCall.Messages) == 0 {
+		t.Fatal("second call has no messages")
+	}
+	lastMsg := secondCall.Messages[len(secondCall.Messages)-1]
+	if len(lastMsg.Content) == 0 || lastMsg.Content[0].OfToolResult == nil {
+		t.Fatal("expected tool_result block in last message")
+	}
+	tr := lastMsg.Content[0].OfToolResult
+	if len(tr.Content) == 0 || tr.Content[0].OfText == nil {
+		t.Fatal("expected text content in tool_result")
+	}
+	return tr.Content[0].OfText.Text
+}
+
+// TestOrchestrator_AllToolResultsPassThroughSanitiser is the
+// contractual test demanded by #83 AC10 / #129 AC: every tool_result
+// content block routed through the orchestrator passes through the
+// shared redact.Sanitise, regardless of whether the producing tool
+// already sanitised its own output. The table covers a single-
+// pattern case per default pattern shape PLUS a multi-pattern case,
+// so a tool whose output bypasses the per-tool layer (new author,
+// third-party integration) still has the floor as a backstop.
+func TestOrchestrator_AllToolResultsPassThroughSanitiser(t *testing.T) {
+	cases := []struct {
+		name        string
+		output      string
+		mustNotHave string
+		mustContain string
+	}{
+		{
+			name:        "aws_access_key",
+			output:      "comment: AKIATESTKEY012345678 planted by attacker",
+			mustNotHave: "AKIATESTKEY012345678",
+			mustContain: "AKIA…REDACTED",
+		},
+		{
+			name:        "github_token",
+			output:      "PAT leaked: ghp_" + strings.Repeat("A", 40) + " end",
+			mustNotHave: strings.Repeat("A", 40),
+			mustContain: "ghp_…REDACTED",
+		},
+		{
+			name:        "openai_anthropic_key",
+			output:      "claude key sk-ant-" + strings.Repeat("d", 40) + " in body",
+			mustNotHave: strings.Repeat("d", 40),
+			mustContain: "sk-…REDACTED",
+		},
+		{
+			name:        "multi_pattern_payload",
+			output:      "AWS=AKIATESTKEY012345678 GH=ghp_" + strings.Repeat("B", 40),
+			mustNotHave: "AKIATESTKEY012345678",
+			mustContain: "AKIA…REDACTED",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := &configurableOutputTool{
+				name:   "test_floor_" + tc.name,
+				output: tc.output,
+			}
+			o, mock := sanitiserTestOrchestrator(t, tool,
+				toolUseResponse("tu_1", tool.Name(), json.RawMessage(`{}`)),
+				textResponse("ok"),
+			)
+			_, err := o.Handle(t.Context(), "!room:server", "test", "maren")
+			if err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+			content := extractToolResultText(t, mock)
+			if strings.Contains(content, tc.mustNotHave) {
+				t.Errorf("raw token leaked through orchestrator floor: %q", content)
+			}
+			if !strings.Contains(content, tc.mustContain) {
+				t.Errorf("expected %q in tool_result content, got: %q",
+					tc.mustContain, content)
+			}
+		})
+	}
+}
+
+// TestOrchestrator_SanitiseIdempotentAtBoundary pins that content
+// already redacted by a per-tool layer (e.g. chips returned
+// `... AKIA…REDACTED ...`) passes through the floor unchanged. This
+// is load-bearing because in steady state with per-tool sanitisers
+// firing, the floor's input IS already-sanitised content — it must
+// be a no-op rather than re-mangle the sentinels.
+func TestOrchestrator_SanitiseIdempotentAtBoundary(t *testing.T) {
+	preSanitised := "result: AKIA…REDACTED and ghp_…REDACTED already redacted upstream"
+	out := orchestrator.SanitiseToolResultContentForTest("any_tool", preSanitised)
+	if out != preSanitised {
+		t.Errorf("pre-sanitised content altered at floor: %q → %q", preSanitised, out)
+	}
+}
+
+// TestOrchestrator_SanitiseLengthCeilingAtBoundary pins that content
+// exceeding MaxSanitiserInputBytes is truncated at the floor even
+// when the tool layer's own MaxOutputLen cap is overridden or
+// bypassed. The floor's cap is inherited from redact.SanitiseWith;
+// this test exercises it via the direct helper because the default
+// sandbox cap (4 096) sits well below MaxSanitiserInputBytes
+// (65 536) and would otherwise mask the floor's truncation.
+func TestOrchestrator_SanitiseLengthCeilingAtBoundary(t *testing.T) {
+	oversized := strings.Repeat("a", redact.MaxSanitiserInputBytes+1024)
+	out := orchestrator.SanitiseToolResultContentForTest("any_tool", oversized)
+	if len(out) > redact.MaxSanitiserInputBytes {
+		t.Errorf("orchestrator floor did not truncate oversized input: got %d bytes, cap %d",
+			len(out), redact.MaxSanitiserInputBytes)
+	}
+}
+
+// TestOrchestrator_SanitiseFailClosedAtBoundary pins the end-to-end
+// fail-closed contract demanded by #129 AC. Install a logger that
+// panics on slog.LevelInfo emissions (the per-pattern attribution
+// line); redact.SanitiseWith's deferred recover catches the panic
+// and emits the Error-level line via the same logger (which does
+// NOT panic on Error), then returns SanitiserErrorReplacement. The
+// orchestrator floor passes that replacement straight through —
+// the orchestrator never sees a raw input through a broken
+// sanitiser, fulfilling the "fail-closed, never silently forward
+// raw content" guarantee.
+func TestOrchestrator_SanitiseFailClosedAtBoundary(t *testing.T) {
+	restore := redact.SetLogger(slog.New(&panicOnInfoHandler{}))
+	defer restore()
+
+	// Input matches the AWS pattern so the floor's for-loop tries to
+	// emit Info attribution, triggering the handler panic.
+	in := "leaked AKIATESTKEY012345678 here"
+	out := orchestrator.SanitiseToolResultContentForTest("any_tool", in)
+	if out != redact.SanitiserErrorReplacement {
+		t.Errorf("expected SanitiserErrorReplacement %q, got %q",
+			redact.SanitiserErrorReplacement, out)
+	}
+	// Crucially, the raw token must NOT have surfaced in the
+	// returned content (the fail-closed replacement substitutes the
+	// entire string).
+	if strings.Contains(out, "AKIATESTKEY012345678") {
+		t.Errorf("raw token surfaced after fail-closed: %q", out)
+	}
+}

--- a/internal/orchestrator/toolloop.go
+++ b/internal/orchestrator/toolloop.go
@@ -11,6 +11,7 @@ import (
 	ctxbuf "klazomenai/bridge/internal/context"
 	"klazomenai/bridge/internal/crew"
 	"klazomenai/bridge/internal/tools"
+	"klazomenai/bridge/internal/tools/redact"
 )
 
 const (
@@ -149,27 +150,37 @@ func (o *Orchestrator) executeToolCalls(ctx context.Context, content []anthropic
 		}
 
 		if !allowed[block.Name] {
+			// block.Name is model-supplied and could itself contain
+			// a token shape. Sanitise once and reuse for both the
+			// orchestrator-level Warn log AND the returned error
+			// content, so the floor's safety guarantee extends to
+			// every emission about this rejected name on this path.
+			safeName := redact.Sanitise(block.Name)
 			slog.Warn("orchestrator: tool not in crew allowlist",
-				"tool", block.Name, "allowed", allowedTools)
+				"tool", safeName, "allowed", allowedTools)
 			results = append(results, anthropic.NewToolResultBlock(
 				block.ID,
-				sanitiseToolResultContent(block.Name,
-					fmt.Sprintf("tool %q not allowed for this crew member", block.Name)),
+				sanitiseToolResultContent(safeName,
+					fmt.Sprintf("tool %q not allowed for this crew member", safeName)),
 				true))
 			continue
 		}
 
 		tool := o.tools.Get(block.Name)
 		if tool == nil {
+			// Same threat as the allowlist path: block.Name is
+			// model-supplied. Derive a sanitised form once for both
+			// the Warn log and the returned error content.
+			safeName := redact.Sanitise(block.Name)
 			slog.Warn("orchestrator: unknown tool requested",
-				"tool", block.Name,
+				"tool", safeName,
 				"crew", crewID,
 				"room", roomID,
 			)
 			results = append(results, anthropic.NewToolResultBlock(
 				block.ID,
-				sanitiseToolResultContent(block.Name,
-					fmt.Sprintf("tool error: unknown tool: %q", block.Name)),
+				sanitiseToolResultContent(safeName,
+					fmt.Sprintf("tool error: unknown tool: %q", safeName)),
 				true))
 			continue
 		}
@@ -185,13 +196,21 @@ func (o *Orchestrator) executeToolCalls(ctx context.Context, content []anthropic
 		// Detect delegation sentinel — only from the delegate_to_crew tool.
 		if !isError && block.Name == tools.DelegateToolName {
 			if targetCrew, delegateCtx, ok := tools.ParseDelegation(result); ok {
+				// targetCrew is parsed from the delegate_to_crew
+				// tool's output, ultimately model-supplied. Sanitise
+				// for slog AND tool_result content. Routing keeps
+				// the raw value (the registry lookup is the
+				// validation surface for that consumer; orchestrator.go's
+				// downstream "following delegation" / "unknown crew"
+				// logs are tracked separately).
+				safeTarget := redact.Sanitise(targetCrew)
 				slog.Info("orchestrator: delegation requested",
-					"from", crewID, "to", targetCrew, "room", roomID)
+					"from", crewID, "to", safeTarget, "room", roomID)
 				*delegation = &delegationRequest{crewID: targetCrew, context: delegateCtx}
 				results = append(results, anthropic.NewToolResultBlock(
 					block.ID,
 					sanitiseToolResultContent(block.Name,
-						fmt.Sprintf("Delegating to %s.", targetCrew)),
+						fmt.Sprintf("Delegating to %s.", safeTarget)),
 					false))
 				return results // skip remaining tools
 			}

--- a/internal/orchestrator/toolloop.go
+++ b/internal/orchestrator/toolloop.go
@@ -152,7 +152,10 @@ func (o *Orchestrator) executeToolCalls(ctx context.Context, content []anthropic
 			slog.Warn("orchestrator: tool not in crew allowlist",
 				"tool", block.Name, "allowed", allowedTools)
 			results = append(results, anthropic.NewToolResultBlock(
-				block.ID, fmt.Sprintf("tool %q not allowed for this crew member", block.Name), true))
+				block.ID,
+				sanitiseToolResultContent(block.Name,
+					fmt.Sprintf("tool %q not allowed for this crew member", block.Name)),
+				true))
 			continue
 		}
 
@@ -164,7 +167,10 @@ func (o *Orchestrator) executeToolCalls(ctx context.Context, content []anthropic
 				"room", roomID,
 			)
 			results = append(results, anthropic.NewToolResultBlock(
-				block.ID, fmt.Sprintf("tool error: unknown tool: %q", block.Name), true))
+				block.ID,
+				sanitiseToolResultContent(block.Name,
+					fmt.Sprintf("tool error: unknown tool: %q", block.Name)),
+				true))
 			continue
 		}
 
@@ -183,12 +189,24 @@ func (o *Orchestrator) executeToolCalls(ctx context.Context, content []anthropic
 					"from", crewID, "to", targetCrew, "room", roomID)
 				*delegation = &delegationRequest{crewID: targetCrew, context: delegateCtx}
 				results = append(results, anthropic.NewToolResultBlock(
-					block.ID, fmt.Sprintf("Delegating to %s.", targetCrew), false))
+					block.ID,
+					sanitiseToolResultContent(block.Name,
+						fmt.Sprintf("Delegating to %s.", targetCrew)),
+					false))
 				return results // skip remaining tools
 			}
 		}
 
-		results = append(results, anthropic.NewToolResultBlock(block.ID, result, isError))
+		// Orchestrator-level safety floor (#129): every tool_result
+		// content block — including the four error paths above —
+		// passes through the shared redact.Sanitise. Per-tool
+		// sanitisers stay as the first line; this is the contractual
+		// guarantee that no raw tool output reaches the model without
+		// the shared pattern set having a final pass at it.
+		results = append(results, anthropic.NewToolResultBlock(
+			block.ID,
+			sanitiseToolResultContent(block.Name, result),
+			isError))
 	}
 
 	return results

--- a/internal/orchestrator/toolloop.go
+++ b/internal/orchestrator/toolloop.go
@@ -217,11 +217,13 @@ func (o *Orchestrator) executeToolCalls(ctx context.Context, content []anthropic
 		}
 
 		// Orchestrator-level safety floor (#129): every tool_result
-		// content block — including the four error paths above —
-		// passes through the shared redact.Sanitise. Per-tool
-		// sanitisers stay as the first line; this is the contractual
-		// guarantee that no raw tool output reaches the model without
-		// the shared pattern set having a final pass at it.
+		// content block — this normal-result path plus the three
+		// special paths above (allowlist refusal, unknown tool,
+		// delegation sentinel) — passes through the shared
+		// redact.Sanitise. Per-tool sanitisers stay as the first
+		// line; this is the contractual guarantee that no raw tool
+		// output reaches the model without the shared pattern set
+		// having a final pass at it.
 		results = append(results, anthropic.NewToolResultBlock(
 			block.ID,
 			sanitiseToolResultContent(block.Name, result),


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's notes

Per-tool sanitisers (Maren's `redactJSON`, Chips' `sanitiseOutput`, Crest's incoming work in #84) live close to the data they redact. That's accurate but incomplete — every new tool author has to remember to wire the sanitiser into their output path, and a single missed `Sanitise()` call leaks a secret into the LLM context. This PR adds the final-pass guarantee #129 calls for: every `tool_result` content block routed through the orchestrator passes through the shared `redact.Sanitise()` shipped in #83, regardless of which tool produced it. Tool-level redaction stays as the first line; this is the safety floor.

## Acceptance criteria

Walking #129's AC against this PR:

| AC item | Status |
|---|---|
| Shared sanitiser package exists at `internal/tools/redact/` (#83 dependency) | ✅ shipped in #170 |
| `internal/orchestrator/toolloop.go` calls `redact.Sanitise()` on every `tool_result` content block before it joins the message history | ✅ wrapped at all 4 `NewToolResultBlock` call sites (allowlist error, unknown-tool error, delegation sentinel, normal tool result) via the new `sanitiseToolResultContent` helper |
| Idempotence test | ✅ `TestOrchestrator_SanitiseIdempotentAtBoundary` — pre-sanitised content passes through unchanged |
| Length-ceiling test | ✅ `TestOrchestrator_SanitiseLengthCeilingAtBoundary` — > `MaxSanitiserInputBytes` input truncated at the floor |
| Fail-closed test | ✅ `TestOrchestrator_SanitiseFailClosedAtBoundary` — handler-panic via Info emission → `SanitiserErrorReplacement` passed through; raw input never reaches Claude |
| `TestOrchestrator_AllToolResultsPassThroughSanitiser` table-drives every registered tool through the orchestrator | ✅ table with 4 mock tools (AWS / GH / OpenAI-Anthropic / multi-pattern); each verifies the planted token does not surface in the resulting tool_result block sent back to Claude |

## Design notes

1. **Single seam, four call sites.** `sanitiseToolResultContent(toolName, content)` wraps `redact.Sanitise` and is threaded through every `NewToolResultBlock` invocation in `executeToolCalls`: the not-in-allowlist error, the unknown-tool error, the delegation sentinel, and the normal tool result. Adding a future `NewToolResultBlock` call without the helper is a code-review-visible regression — the helper is the convention.

2. **Attribution logging carries `layer=orchestrator_floor`.** Per-tool sanitisers emit with `tool=<name>` + `field=output`; the floor emits with `layer=orchestrator_floor`, `tool=<name>`, `field=tool_result`. Operators grep `layer=orchestrator_floor` to surface cases where the per-tool layer missed a leak and the floor caught it — an interesting signal that should be alert-worthy. In steady state (per-tool layers doing their job), the floor sees already-sanitised content and emits nothing because `FindAllStringIndex` returns zero matches.

3. **Idempotence is load-bearing.** In steady state the floor's input IS what per-tool layers produced — already-sanitised. Re-applying the same patterns must be a no-op rather than re-mangle the sentinels. The U+2026 ellipsis (`…`) in replacements breaks the originating regex character classes; `Bearer REDACTED` and `${1}REDACTED` are fixed points by construction. Pinned in the test.

4. **Fail-closed survives a panic.** A regex-panic in `SanitiseWith` is caught by its own `defer recover`, which emits the Error line via the swappable logger and returns `SanitiserErrorReplacement`. The floor passes that through to the tool_result content. The model never sees raw input when the sanitiser fails. The end-to-end test installs a `panicOnInfoHandler` that panics on `slog.LevelInfo` emissions (but not on Error) — covers the realistic scenario of a broken handler routed via `redact.SetLogger`.

5. **Test seam `SanitiseToolResultContentForTest`.** Exposes the helper to the external test package so the idempotence, length-ceiling, and fail-closed tests drive it directly. The default tool sandbox caps output at 4 096 bytes (`tools.DefaultMaxOutputLen`), so the floor's 64 KiB cap can't be exercised end-to-end through the orchestrator's normal tool path — the direct test is the only realistic way to pin the floor's own ceiling.

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./internal/orchestrator/...` clean
- [x] `CGO_ENABLED=0 go test -tags goolm -count=1 ./internal/...` — all 14 internal packages green
- [x] `internal/orchestrator/sanitise.go` (helper) at 100% per `go tool cover -func`
- [x] Orchestrator package coverage 94.4% (existing uncovered statements unchanged)
- [ ] Manual smoke after deploy: a chips tool reading an issue body that contains a planted `AKIA…` shape returns output where the raw token is replaced with `AKIA…REDACTED` AND any leak that bypassed chips' per-tool layer is also caught by the floor (visible as a `layer=orchestrator_floor` log line)

## Out of scope / follow-up

- **#171** — `bridge_tool_redactions_total` Prometheus counter, gated on #89's `/metrics` endpoint. Same emission site; ~5 LOC when #89 lands.
- **#84 (Crest)** + **#85 (Maren)** — companion per-tool redaction issues; both consume the same shared `redact` package. The floor backstops them too.

Closes #129
Refs #83
Refs #84
Refs #85
