### PR TITLE
feat(chips): GitHub PAT from secret file + insecure-token-from-env dev flag 🔐

### DIFF
--- a/cmd/bridge/githubauth.go
+++ b/cmd/bridge/githubauth.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// DefaultGitHubTokenPath is the file mount used by the Helm chart in
+// `klazomenai/AKeyRA/helm/bridge/templates/deployment.yaml` when
+// `chips.enabled` is true. Mirrors the Anthropic-key precedent
+// (/run/secrets/anthropic/api_key).
+const DefaultGitHubTokenPath = "/run/secrets/github/token"
+
+// LoadGitHubToken returns the Chips GitHub PAT used by the chips
+// gh_*/git_* tools to authenticate against the GitHub API. Returns
+// the empty string when no token is configured — the caller registers
+// stub tools in that case (same behaviour as the pre-#141 env-only
+// path).
+//
+// Default behaviour: reads the token from the file at the path
+// GITHUB_TOKEN_FILE (defaulting to DefaultGitHubTokenPath). The
+// returned value is whitespace-trimmed — Vault writes the literal
+// PAT, but mounted K8s Secrets may carry a trailing newline depending
+// on how the secret was created. Trimming makes both shapes produce
+// the same token string.
+//
+// Missing file → empty token → stub tools registered, no error. The
+// stub branch is the chart's default state (chips.enabled=false) and
+// every consumer of LoadGitHubToken must handle an empty return.
+//
+// When insecureFromEnv is true (operator passed --insecure-token-
+// from-env on the bridge command line), the loader reads from the
+// GITHUB_TOKEN env var instead and emits a one-shot slog.Warn line.
+// This path is intended for local development only — production
+// deployments should leave it false (the default). Env-var-mounted
+// secrets are exposed via /proc/<pid>/environ to anyone with read
+// access in the container's PID namespace, while a Secret-mounted
+// file is read once at startup and never written into the process
+// environment.
+//
+// The token value itself is NEVER logged. Both code paths emit only
+// metadata (file path, presence boolean, rune count of the trimmed
+// value) so an operator can confirm a token was loaded without the
+// value appearing in log infrastructure.
+func LoadGitHubToken(insecureFromEnv bool) (string, error) {
+	if insecureFromEnv {
+		v := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+		slog.Warn(
+			"chips: GITHUB_TOKEN loaded from env via --insecure-token-from-env (dev only)",
+			"present", v != "",
+			"rune_count", len([]rune(v)),
+		)
+		return v, nil
+	}
+
+	path := os.Getenv("GITHUB_TOKEN_FILE")
+	if path == "" {
+		path = DefaultGitHubTokenPath
+	}
+
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		// Default chart state (chips.enabled=false) doesn't mount the
+		// Secret, so the file is absent. Caller registers stubs.
+		slog.Info("chips: GITHUB_TOKEN_FILE not present; stub tools will register",
+			"path", path,
+		)
+		return "", nil
+	}
+	if err != nil {
+		// Permission denied, IO error, etc. — surface to the caller
+		// so main() can decide whether to exit or fall through to
+		// stubs. The path is logged but the token contents are not
+		// (and aren't available — the read failed).
+		return "", fmt.Errorf("read GITHUB_TOKEN_FILE %q: %w", path, err)
+	}
+
+	token := strings.TrimSpace(string(raw))
+	slog.Info("chips: GITHUB_TOKEN loaded from file",
+		"path", path,
+		"present", token != "",
+		"rune_count", len([]rune(token)),
+	)
+	return token, nil
+}

--- a/cmd/bridge/githubauth_test.go
+++ b/cmd/bridge/githubauth_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureSlog routes the default slog logger to a buffer for the
+// duration of one test. Used to assert that the token loader does
+// not leak the raw token value into any log line — the "token never
+// logged" half of #141's AC.
+func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+	return &buf, func() { slog.SetDefault(original) }
+}
+
+func TestLoadGitHubToken_FromFile_CustomPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("ghp_test_token_value\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	t.Setenv("GITHUB_TOKEN_FILE", path)
+
+	tok, err := LoadGitHubToken(false)
+	if err != nil {
+		t.Fatalf("LoadGitHubToken: %v", err)
+	}
+	if tok != "ghp_test_token_value" {
+		t.Errorf("token = %q, want ghp_test_token_value (trimmed)", tok)
+	}
+}
+
+func TestLoadGitHubToken_FromFile_TrimsTrailingNewline(t *testing.T) {
+	// K8s Secrets mounted via the helm chart can include a trailing
+	// newline depending on how the secret was created. The loader
+	// strips it so the consumer doesn't pass "ghp_xxx\n" to gh CLI
+	// (which rejects tokens with whitespace).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("ghp_with_newline\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_TOKEN_FILE", path)
+
+	tok, _ := LoadGitHubToken(false)
+	if tok != "ghp_with_newline" {
+		t.Errorf("trailing newline not trimmed: %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_FromFile_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("  \tghp_padded\t  \n\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_TOKEN_FILE", path)
+
+	tok, _ := LoadGitHubToken(false)
+	if tok != "ghp_padded" {
+		t.Errorf("whitespace not trimmed: %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_FileMissing_ReturnsEmptyNoError(t *testing.T) {
+	// Default chart state (chips.enabled=false) doesn't create the
+	// Secret, so the file is absent. The loader returns "" + nil so
+	// the caller registers stub tools — same shape as pre-#141 when
+	// GITHUB_TOKEN env was unset.
+	t.Setenv("GITHUB_TOKEN_FILE", "/nonexistent/path/never/exists")
+
+	tok, err := LoadGitHubToken(false)
+	if err != nil {
+		t.Errorf("missing file should not error, got: %v", err)
+	}
+	if tok != "" {
+		t.Errorf("missing file should return empty, got %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_FileEmpty_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_TOKEN_FILE", path)
+
+	tok, err := LoadGitHubToken(false)
+	if err != nil {
+		t.Errorf("empty file should not error, got: %v", err)
+	}
+	if tok != "" {
+		t.Errorf("empty file should return empty, got %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_DefaultPathWhenEnvUnset(t *testing.T) {
+	// With GITHUB_TOKEN_FILE unset, the loader falls back to
+	// DefaultGitHubTokenPath (/run/secrets/github/token). That path
+	// won't exist in the test env, so we expect empty+nil (the
+	// missing-file branch) — proving the fallback wiring works.
+	t.Setenv("GITHUB_TOKEN_FILE", "")
+
+	tok, err := LoadGitHubToken(false)
+	if err != nil {
+		t.Errorf("default path should not error when missing, got: %v", err)
+	}
+	if tok != "" {
+		t.Errorf("default path missing should return empty, got %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_InsecureFromEnv_ReadsEnvVar(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_env_only_value")
+	// GITHUB_TOKEN_FILE is irrelevant when insecureFromEnv is true.
+	t.Setenv("GITHUB_TOKEN_FILE", "/some/path/that/should/be/ignored")
+
+	tok, err := LoadGitHubToken(true)
+	if err != nil {
+		t.Fatalf("LoadGitHubToken(true): %v", err)
+	}
+	if tok != "ghp_env_only_value" {
+		t.Errorf("env path: token = %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_InsecureFromEnv_TrimsWhitespace(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "  ghp_env_padded  ")
+
+	tok, _ := LoadGitHubToken(true)
+	if tok != "ghp_env_padded" {
+		t.Errorf("env whitespace not trimmed: %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_InsecureFromEnv_EmptyReturnsEmpty(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+
+	tok, err := LoadGitHubToken(true)
+	if err != nil {
+		t.Errorf("empty env should not error, got: %v", err)
+	}
+	if tok != "" {
+		t.Errorf("empty env should return empty, got %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_FileTakesPrecedenceOverEnv(t *testing.T) {
+	// When insecureFromEnv is FALSE, GITHUB_TOKEN env is completely
+	// ignored — only the file path source is consulted. Documents
+	// the #142 AC "either deprecated cleanly or kept with documented
+	// precedence" decision for the token side: file is the single
+	// source of truth in production; env is dev-only via the flag.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("ghp_from_file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_TOKEN_FILE", path)
+	t.Setenv("GITHUB_TOKEN", "ghp_from_env_should_be_ignored")
+
+	tok, err := LoadGitHubToken(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok != "ghp_from_file" {
+		t.Errorf("env shadowed file: %q", tok)
+	}
+}
+
+func TestLoadGitHubToken_TokenNeverLoggedFromFile(t *testing.T) {
+	// #141 AC: "Token is never logged, even in debug mode". Capture
+	// every slog line emitted during a load and assert the literal
+	// token value does NOT appear. The loader emits a metadata-only
+	// info line (path, present bool, rune count); the value itself
+	// must not surface anywhere in those structured fields.
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	const secret = "ghp_DO_NOT_LOG_unique_secret_value_42"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_TOKEN_FILE", path)
+
+	if _, err := LoadGitHubToken(false); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(buf.String(), secret) {
+		t.Errorf("raw token leaked into slog output: %s", buf.String())
+	}
+}
+
+func TestLoadGitHubToken_TokenNeverLoggedFromEnv(t *testing.T) {
+	// Same contract on the --insecure-token-from-env code path.
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	const secret = "ghp_env_path_DO_NOT_LOG_value_99"
+	t.Setenv("GITHUB_TOKEN", secret)
+
+	if _, err := LoadGitHubToken(true); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(buf.String(), secret) {
+		t.Errorf("raw token leaked into slog output (env path): %s", buf.String())
+	}
+}
+
+func TestLoadGitHubToken_PermissionError_Surfaces(t *testing.T) {
+	// Unexpected file-read failures (permission denied, IO error)
+	// surface to the caller rather than silently returning empty —
+	// otherwise an operator misconfiguration that prevents the
+	// bridge from reading a configured secret would silently fall
+	// through to stub tools, hiding the real issue.
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission test won't trigger EACCES")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("ghp_unreachable"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_TOKEN_FILE", path)
+
+	_, err := LoadGitHubToken(false)
+	if err == nil {
+		t.Error("expected error on unreadable file, got nil")
+	}
+	// Error message includes the path (for triage) but not the
+	// token (we couldn't read it anyway).
+	if err != nil && !strings.Contains(err.Error(), path) {
+		t.Errorf("error should mention path: %v", err)
+	}
+}

--- a/cmd/bridge/githubauth_test.go
+++ b/cmd/bridge/githubauth_test.go
@@ -12,13 +12,18 @@ import (
 // captureSlog routes the default slog logger to a buffer for the
 // duration of one test. Used to assert that the token loader does
 // not leak the raw token value into any log line — the "token never
-// logged" half of #141's AC.
+// logged, even in debug mode" half of #141's AC.
+//
+// Handler level is LevelDebug so a future regression that adds e.g.
+// slog.Debug("loaded token", "value", token) is caught — at LevelInfo
+// the Debug emission would be filtered out before reaching the
+// buffer, and the absent-token assertion below would vacuously pass.
 func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
 	t.Helper()
 	var buf bytes.Buffer
 	original := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: slog.LevelDebug,
 	})))
 	return &buf, func() { slog.SetDefault(original) }
 }

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -172,9 +172,16 @@ func main() {
 	}
 	chipsRepoCSV := os.Getenv("CHIPS_REPO_ALLOWLIST")
 	if ghToken != "" && chipsRepoCSV != "" && hasExec("gh") && hasExec("git") {
+		// DefaultExecFnWithToken injects GITHUB_TOKEN into each gh
+		// subprocess's environment without putting the token in the
+		// bridge's own os.Environ(). This keeps the token out of
+		// /proc/<bridge-pid>/environ (the whole motivation for the
+		// #141 file-mount path) while still authenticating gh CLI
+		// calls — gh reads GITHUB_TOKEN from its env to talk to the
+		// GitHub API.
 		chipstools.RegisterChipsTools(
 			toolReg,
-			chipstools.DefaultExecFn(),
+			chipstools.DefaultExecFnWithToken(ghToken),
 			chipstools.ParseRepoAllowlist(chipsRepoCSV),
 			ghToken,
 		)

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"log/slog"
 	"net/http"
 	"os"
@@ -31,6 +32,19 @@ import (
 )
 
 func main() {
+	// --- Command-line flags ---
+	// --insecure-token-from-env (default false): when set, the Chips
+	// GitHub PAT is read from the GITHUB_TOKEN env var instead of the
+	// mounted secret file at /run/secrets/github/token. Production
+	// deployments mount the file via the helm chart's chips.enabled
+	// values gate; this flag is for local dev where mounting a
+	// Kubernetes secret is impractical. See LoadGitHubToken's
+	// docstring for the security trade-off (env vars are exposed via
+	// /proc/<pid>/environ; file-mounted secrets are not).
+	insecureTokenFromEnv := flag.Bool("insecure-token-from-env", false,
+		"read GITHUB_TOKEN from env var instead of /run/secrets/github/token (DEV ONLY; bypasses the chart's file-mount path)")
+	flag.Parse()
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
@@ -140,7 +154,22 @@ func main() {
 	}
 
 	// --- Chips tools ---
-	ghToken := os.Getenv("GITHUB_TOKEN")
+	// GitHub PAT loaded from /run/secrets/github/token (or env via the
+	// --insecure-token-from-env dev flag); allowlist is a CSV env var
+	// rendered by helm/bridge/templates/deployment.yaml from
+	// chips.repoAllowlist in values.yaml. Empty token or empty CSV →
+	// stub tools (chart's chips.enabled=false default).
+	ghToken, err := LoadGitHubToken(*insecureTokenFromEnv)
+	if err != nil {
+		slog.Error("chips: failed to load GitHub token; registering stubs",
+			"err", err)
+		// Fall through with empty token — caller's existing branch
+		// registers stub tools. Surfacing the error in the log lets
+		// operators triage misconfigured GITHUB_TOKEN_FILE without
+		// the bridge failing to start (Anthropic key is the only
+		// hard requirement; Chips is a feature, not the core).
+		ghToken = ""
+	}
 	chipsRepoCSV := os.Getenv("CHIPS_REPO_ALLOWLIST")
 	if ghToken != "" && chipsRepoCSV != "" && hasExec("gh") && hasExec("git") {
 		chipstools.RegisterChipsTools(

--- a/internal/tools/chips/chips_test.go
+++ b/internal/tools/chips/chips_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -480,63 +481,99 @@ func TestTokenSanitisedInOutput(t *testing.T) {
 	}
 }
 
-// --- DefaultExecFnWithToken env injection ---
+// --- DefaultExecFnWithToken end-to-end env injection ---
 //
 // These tests cover the production path established by bridge#141 +
-// the Copilot review on PR #174: the bridge loads GITHUB_TOKEN from
-// a mounted secret file (off os.Environ()) and injects it into each
-// gh subprocess via Cmd.Env. Pre-#174 this had been done implicitly
-// via env-var inheritance — once the file-mount lands, the env-var
-// is gone from the bridge and gh would run unauthenticated unless
-// we inject explicitly.
+// the Copilot review on PR #174. The pure-function gating + filter
+// logic is unit-tested in exec_internal_test.go via buildGhChildEnv
+// directly; the tests below verify end-to-end subprocess behaviour
+// using a temp `gh` stub script, which exercises the path where
+// Go's exec.CommandContext actually applies Cmd.Env to the child.
 
-func TestDefaultExecFnWithTokenInjectsGitHubToken(t *testing.T) {
+// makeGhStub writes a shell script named `gh` into a fresh temp
+// directory and returns its full path. The script prints the
+// child's gh-auth env vars in a stable format so tests can assert
+// on exact content. Used to verify DefaultExecFnWithToken's
+// filepath.Base("gh") gating end-to-end without needing the real
+// gh CLI in the test environment.
+func makeGhStub(t *testing.T) string {
+	t.Helper()
 	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("no /bin/sh on this host — skipping subprocess env check")
+		t.Skip("no /bin/sh on this host — skipping subprocess test")
 	}
-	fn := chips.DefaultExecFnWithToken("ghp_test_injected_value")
-	out, err := fn(t.Context(), "sh", "-c", "printf %s \"$GITHUB_TOKEN\"")
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "gh")
+	script := []byte(`#!/bin/sh
+printf "GH_TOKEN=%s|GITHUB_TOKEN=%s" "$GH_TOKEN" "$GITHUB_TOKEN"
+`)
+	if err := os.WriteFile(stub, script, 0o755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	return stub
+}
+
+func TestDefaultExecFnWithToken_InjectsForGhCommand_EndToEnd(t *testing.T) {
+	// Single end-to-end subprocess test that proves the helper
+	// (a) gates on filepath.Base("gh"), (b) filters parent's stray
+	// GH_TOKEN/GITHUB_TOKEN, and (c) the injected value reaches the
+	// child via Cmd.Env. The gh stub is invoked by its full path
+	// (/tmp/.../gh) so the test also covers basename-of-a-path
+	// resolution.
+	stub := makeGhStub(t)
+	t.Setenv("GH_TOKEN", "stray_should_be_filtered")
+	t.Setenv("GITHUB_TOKEN", "also_stray")
+
+	fn := chips.DefaultExecFnWithToken("ghp_authoritative_value")
+	out, err := fn(t.Context(), stub)
 	if err != nil {
-		t.Fatalf("exec sh: %v", err)
+		t.Fatalf("exec gh stub: %v", err)
 	}
-	if string(out) != "ghp_test_injected_value" {
-		t.Errorf("child saw GITHUB_TOKEN=%q, want ghp_test_injected_value", out)
+	want := "GH_TOKEN=|GITHUB_TOKEN=ghp_authoritative_value"
+	if string(out) != want {
+		t.Errorf("child env mismatch:\n  got:  %q\n  want: %q", out, want)
 	}
 }
 
-func TestDefaultExecFnWithTokenEmptyTokenSkipsInjection(t *testing.T) {
-	// Empty token → ExecFn matches DefaultExecFn behaviour (no
-	// Cmd.Env override). If the parent has GITHUB_TOKEN set, the
-	// child inherits it; if not, the child sees empty.
+func TestDefaultExecFnWithToken_DoesNotInjectForNonGhCommand(t *testing.T) {
+	// `git log` / `git diff` subprocesses (and any other non-gh
+	// command) MUST NOT receive GITHUB_TOKEN — they don't need it
+	// and the file-mount path's whole point is to keep the token's
+	// /proc/<pid>/environ exposure as narrow as possible. With
+	// the basename gating, name="sh" (or "git", or anything else)
+	// leaves Cmd.Env=nil, so the child inherits parent's
+	// GITHUB_TOKEN as-is. Verified here by setting a marker value
+	// on parent and observing it pass through unchanged.
 	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("no /bin/sh on this host — skipping subprocess env check")
+		t.Skip("no /bin/sh on this host")
 	}
-	// Clear parent env so the inheritance test is deterministic.
-	t.Setenv("GITHUB_TOKEN", "")
-	fn := chips.DefaultExecFnWithToken("")
-	out, err := fn(t.Context(), "sh", "-c", "printf %s \"$GITHUB_TOKEN\"")
+	const sentinel = "parent_value_must_pass_through_for_non_gh"
+	t.Setenv("GITHUB_TOKEN", sentinel)
+
+	fn := chips.DefaultExecFnWithToken("ghp_should_not_be_injected_for_sh")
+	out, err := fn(t.Context(), "sh", "-c", `printf "%s" "$GITHUB_TOKEN"`)
 	if err != nil {
 		t.Fatalf("exec sh: %v", err)
 	}
-	if string(out) != "" {
-		t.Errorf("expected empty GITHUB_TOKEN with empty-token + cleared env, got %q", out)
+	if string(out) != sentinel {
+		t.Errorf("non-gh command got injected token:\n  got:  %q\n  want: %q (parent passthrough)", out, sentinel)
 	}
 }
 
-func TestDefaultExecFnWithTokenDoesNotPolluteParentEnv(t *testing.T) {
+func TestDefaultExecFnWithToken_DoesNotPolluteParentEnv(t *testing.T) {
 	// The whole point of the file-mount path is that the bridge's
-	// own os.Environ() does NOT contain GITHUB_TOKEN. The exec
-	// helper must inject into the child's Cmd.Env only — never
-	// os.Setenv into the parent. This test confirms by snapshotting
-	// the parent env before+after a subprocess call.
+	// own os.Environ() does NOT contain GITHUB_TOKEN. Even when
+	// the helper IS configured to inject (token non-empty + gh
+	// command name), it must inject into the child's Cmd.Env only —
+	// never os.Setenv into the parent. Snapshot before+after.
+	stub := makeGhStub(t)
 	t.Setenv("GITHUB_TOKEN", "")
 	if v := os.Getenv("GITHUB_TOKEN"); v != "" {
 		t.Fatalf("test setup: GITHUB_TOKEN should be empty pre-call, got %q", v)
 	}
 
 	fn := chips.DefaultExecFnWithToken("ghp_must_not_leak_into_parent")
-	if _, err := fn(t.Context(), "true"); err != nil {
-		t.Fatalf("exec true: %v", err)
+	if _, err := fn(t.Context(), stub); err != nil {
+		t.Fatalf("exec gh stub: %v", err)
 	}
 
 	if v := os.Getenv("GITHUB_TOKEN"); v != "" {
@@ -544,77 +581,25 @@ func TestDefaultExecFnWithTokenDoesNotPolluteParentEnv(t *testing.T) {
 	}
 }
 
-func TestDefaultExecFnWithTokenAppendsRatherThanReplaces(t *testing.T) {
-	// Existing env vars (e.g. PATH) must reach the child, otherwise
-	// gh wouldn't find its dependencies. The helper builds the
-	// child env by filtering the parent's gh-auth env vars and
-	// appending its own GITHUB_TOKEN — every other parent entry
-	// passes through unchanged.
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("no /bin/sh on this host — skipping subprocess env check")
-	}
-	// Set a marker env var on the parent (NOT a gh-auth var, so it
-	// must survive the filter).
-	t.Setenv("BRIDGE_ENV_MARKER", "ok")
-	fn := chips.DefaultExecFnWithToken("ghp_irrelevant")
-	out, err := fn(t.Context(), "sh", "-c", "printf %s \"$BRIDGE_ENV_MARKER\"")
-	if err != nil {
-		t.Fatalf("exec sh: %v", err)
-	}
-	if string(out) != "ok" {
-		t.Errorf("child did not inherit parent env: BRIDGE_ENV_MARKER=%q", out)
-	}
-}
+func TestDefaultExecFnWithToken_EmptyTokenSkipsInjection(t *testing.T) {
+	// Empty token → no Cmd.Env override regardless of command name.
+	// Child inherits parent's GITHUB_TOKEN unchanged. The gh stub
+	// is used so we exercise the same code path as the inject
+	// case; only the token value differs.
+	stub := makeGhStub(t)
+	const sentinel = "parent_should_pass_through_for_empty_token"
+	t.Setenv("GITHUB_TOKEN", sentinel)
 
-func TestDefaultExecFnWithTokenFiltersPreExistingGHToken(t *testing.T) {
-	// gh CLI gives GH_TOKEN precedence over GITHUB_TOKEN. A stray
-	// GH_TOKEN in the bridge's env (operator misconfiguration,
-	// devenv shell leak, container build artifact) would silently
-	// override the file-mounted token and authenticate gh with
-	// whatever value GH_TOKEN had — defeating the point of the
-	// file-mount path. The helper filters BOTH GH_TOKEN and
-	// GITHUB_TOKEN from the inherited env before injecting its own
-	// GITHUB_TOKEN, guaranteeing the loaded token is the only
-	// signal the child sees.
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("no /bin/sh on this host — skipping subprocess env check")
-	}
-	t.Setenv("GH_TOKEN", "ghp_stray_parent_value_should_be_filtered")
-	t.Setenv("GITHUB_TOKEN", "ghp_also_filtered")
-
-	fn := chips.DefaultExecFnWithToken("ghp_authoritative_file_value")
-	// Print both env vars from the child; GITHUB_TOKEN should be
-	// our injected value, GH_TOKEN should be absent (empty).
-	out, err := fn(t.Context(), "sh", "-c",
-		`printf "GH_TOKEN=%s|GITHUB_TOKEN=%s" "$GH_TOKEN" "$GITHUB_TOKEN"`)
+	fn := chips.DefaultExecFnWithToken("")
+	out, err := fn(t.Context(), stub)
 	if err != nil {
-		t.Fatalf("exec sh: %v", err)
+		t.Fatalf("exec gh stub: %v", err)
 	}
-	want := "GH_TOKEN=|GITHUB_TOKEN=ghp_authoritative_file_value"
+	// Stub prints both GH_TOKEN and GITHUB_TOKEN; GH_TOKEN unset
+	// here so the GITHUB_TOKEN= portion is what we care about.
+	want := "GH_TOKEN=|GITHUB_TOKEN=" + sentinel
 	if string(out) != want {
-		t.Errorf("child env mismatch:\n  got:  %q\n  want: %q", out, want)
-	}
-}
-
-func TestDefaultExecFnWithTokenFiltersBothEvenWhenTokenInjectedMatches(t *testing.T) {
-	// Edge case: parent has GH_TOKEN set to the same value the
-	// caller is injecting. The filter still drops GH_TOKEN before
-	// the append, so the child sees only GITHUB_TOKEN. Pins that
-	// GH_TOKEN is unconditionally filtered — there is no scenario
-	// where gh CLI sees GH_TOKEN from the child env.
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("no /bin/sh on this host — skipping subprocess env check")
-	}
-	sameValue := "ghp_same_value_on_both_sides"
-	t.Setenv("GH_TOKEN", sameValue)
-
-	fn := chips.DefaultExecFnWithToken(sameValue)
-	out, err := fn(t.Context(), "sh", "-c", `printf "%s" "$GH_TOKEN"`)
-	if err != nil {
-		t.Fatalf("exec sh: %v", err)
-	}
-	if string(out) != "" {
-		t.Errorf("GH_TOKEN reached child despite filter: %q", out)
+		t.Errorf("empty token: child env mismatch:\n  got:  %q\n  want: %q", out, want)
 	}
 }
 

--- a/internal/tools/chips/chips_test.go
+++ b/internal/tools/chips/chips_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -475,6 +477,89 @@ func TestTokenSanitisedInOutput(t *testing.T) {
 	}
 	if !strings.Contains(out, "[REDACTED]") {
 		t.Error("expected [REDACTED] in output")
+	}
+}
+
+// --- DefaultExecFnWithToken env injection ---
+//
+// These tests cover the production path established by bridge#141 +
+// the Copilot review on PR #174: the bridge loads GITHUB_TOKEN from
+// a mounted secret file (off os.Environ()) and injects it into each
+// gh subprocess via Cmd.Env. Pre-#174 this had been done implicitly
+// via env-var inheritance — once the file-mount lands, the env-var
+// is gone from the bridge and gh would run unauthenticated unless
+// we inject explicitly.
+
+func TestDefaultExecFnWithTokenInjectsGitHubToken(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no /bin/sh on this host — skipping subprocess env check")
+	}
+	fn := chips.DefaultExecFnWithToken("ghp_test_injected_value")
+	out, err := fn(t.Context(), "sh", "-c", "printf %s \"$GITHUB_TOKEN\"")
+	if err != nil {
+		t.Fatalf("exec sh: %v", err)
+	}
+	if string(out) != "ghp_test_injected_value" {
+		t.Errorf("child saw GITHUB_TOKEN=%q, want ghp_test_injected_value", out)
+	}
+}
+
+func TestDefaultExecFnWithTokenEmptyTokenSkipsInjection(t *testing.T) {
+	// Empty token → ExecFn matches DefaultExecFn behaviour (no
+	// Cmd.Env override). If the parent has GITHUB_TOKEN set, the
+	// child inherits it; if not, the child sees empty.
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no /bin/sh on this host — skipping subprocess env check")
+	}
+	// Clear parent env so the inheritance test is deterministic.
+	t.Setenv("GITHUB_TOKEN", "")
+	fn := chips.DefaultExecFnWithToken("")
+	out, err := fn(t.Context(), "sh", "-c", "printf %s \"$GITHUB_TOKEN\"")
+	if err != nil {
+		t.Fatalf("exec sh: %v", err)
+	}
+	if string(out) != "" {
+		t.Errorf("expected empty GITHUB_TOKEN with empty-token + cleared env, got %q", out)
+	}
+}
+
+func TestDefaultExecFnWithTokenDoesNotPolluteParentEnv(t *testing.T) {
+	// The whole point of the file-mount path is that the bridge's
+	// own os.Environ() does NOT contain GITHUB_TOKEN. The exec
+	// helper must inject into the child's Cmd.Env only — never
+	// os.Setenv into the parent. This test confirms by snapshotting
+	// the parent env before+after a subprocess call.
+	t.Setenv("GITHUB_TOKEN", "")
+	if v := os.Getenv("GITHUB_TOKEN"); v != "" {
+		t.Fatalf("test setup: GITHUB_TOKEN should be empty pre-call, got %q", v)
+	}
+
+	fn := chips.DefaultExecFnWithToken("ghp_must_not_leak_into_parent")
+	if _, err := fn(t.Context(), "true"); err != nil {
+		t.Fatalf("exec true: %v", err)
+	}
+
+	if v := os.Getenv("GITHUB_TOKEN"); v != "" {
+		t.Errorf("parent os.Environ() polluted by DefaultExecFnWithToken: GITHUB_TOKEN=%q", v)
+	}
+}
+
+func TestDefaultExecFnWithTokenAppendsRatherThanReplaces(t *testing.T) {
+	// Existing env vars (e.g. PATH) must reach the child, otherwise
+	// gh wouldn't find its dependencies. The helper appends to
+	// os.Environ() rather than building a fresh slice.
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no /bin/sh on this host — skipping subprocess env check")
+	}
+	// Set a marker env var on the parent.
+	t.Setenv("BRIDGE_ENV_MARKER", "ok")
+	fn := chips.DefaultExecFnWithToken("ghp_irrelevant")
+	out, err := fn(t.Context(), "sh", "-c", "printf %s \"$BRIDGE_ENV_MARKER\"")
+	if err != nil {
+		t.Fatalf("exec sh: %v", err)
+	}
+	if string(out) != "ok" {
+		t.Errorf("child did not inherit parent env: BRIDGE_ENV_MARKER=%q", out)
 	}
 }
 

--- a/internal/tools/chips/chips_test.go
+++ b/internal/tools/chips/chips_test.go
@@ -546,12 +546,15 @@ func TestDefaultExecFnWithTokenDoesNotPolluteParentEnv(t *testing.T) {
 
 func TestDefaultExecFnWithTokenAppendsRatherThanReplaces(t *testing.T) {
 	// Existing env vars (e.g. PATH) must reach the child, otherwise
-	// gh wouldn't find its dependencies. The helper appends to
-	// os.Environ() rather than building a fresh slice.
+	// gh wouldn't find its dependencies. The helper builds the
+	// child env by filtering the parent's gh-auth env vars and
+	// appending its own GITHUB_TOKEN — every other parent entry
+	// passes through unchanged.
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("no /bin/sh on this host — skipping subprocess env check")
 	}
-	// Set a marker env var on the parent.
+	// Set a marker env var on the parent (NOT a gh-auth var, so it
+	// must survive the filter).
 	t.Setenv("BRIDGE_ENV_MARKER", "ok")
 	fn := chips.DefaultExecFnWithToken("ghp_irrelevant")
 	out, err := fn(t.Context(), "sh", "-c", "printf %s \"$BRIDGE_ENV_MARKER\"")
@@ -560,6 +563,58 @@ func TestDefaultExecFnWithTokenAppendsRatherThanReplaces(t *testing.T) {
 	}
 	if string(out) != "ok" {
 		t.Errorf("child did not inherit parent env: BRIDGE_ENV_MARKER=%q", out)
+	}
+}
+
+func TestDefaultExecFnWithTokenFiltersPreExistingGHToken(t *testing.T) {
+	// gh CLI gives GH_TOKEN precedence over GITHUB_TOKEN. A stray
+	// GH_TOKEN in the bridge's env (operator misconfiguration,
+	// devenv shell leak, container build artifact) would silently
+	// override the file-mounted token and authenticate gh with
+	// whatever value GH_TOKEN had — defeating the point of the
+	// file-mount path. The helper filters BOTH GH_TOKEN and
+	// GITHUB_TOKEN from the inherited env before injecting its own
+	// GITHUB_TOKEN, guaranteeing the loaded token is the only
+	// signal the child sees.
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no /bin/sh on this host — skipping subprocess env check")
+	}
+	t.Setenv("GH_TOKEN", "ghp_stray_parent_value_should_be_filtered")
+	t.Setenv("GITHUB_TOKEN", "ghp_also_filtered")
+
+	fn := chips.DefaultExecFnWithToken("ghp_authoritative_file_value")
+	// Print both env vars from the child; GITHUB_TOKEN should be
+	// our injected value, GH_TOKEN should be absent (empty).
+	out, err := fn(t.Context(), "sh", "-c",
+		`printf "GH_TOKEN=%s|GITHUB_TOKEN=%s" "$GH_TOKEN" "$GITHUB_TOKEN"`)
+	if err != nil {
+		t.Fatalf("exec sh: %v", err)
+	}
+	want := "GH_TOKEN=|GITHUB_TOKEN=ghp_authoritative_file_value"
+	if string(out) != want {
+		t.Errorf("child env mismatch:\n  got:  %q\n  want: %q", out, want)
+	}
+}
+
+func TestDefaultExecFnWithTokenFiltersBothEvenWhenTokenInjectedMatches(t *testing.T) {
+	// Edge case: parent has GH_TOKEN set to the same value the
+	// caller is injecting. The filter still drops GH_TOKEN before
+	// the append, so the child sees only GITHUB_TOKEN. Pins that
+	// GH_TOKEN is unconditionally filtered — there is no scenario
+	// where gh CLI sees GH_TOKEN from the child env.
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no /bin/sh on this host — skipping subprocess env check")
+	}
+	sameValue := "ghp_same_value_on_both_sides"
+	t.Setenv("GH_TOKEN", sameValue)
+
+	fn := chips.DefaultExecFnWithToken(sameValue)
+	out, err := fn(t.Context(), "sh", "-c", `printf "%s" "$GH_TOKEN"`)
+	if err != nil {
+		t.Fatalf("exec sh: %v", err)
+	}
+	if string(out) != "" {
+		t.Errorf("GH_TOKEN reached child despite filter: %q", out)
 	}
 }
 

--- a/internal/tools/chips/chips_test.go
+++ b/internal/tools/chips/chips_test.go
@@ -534,28 +534,27 @@ func TestDefaultExecFnWithToken_InjectsForGhCommand_EndToEnd(t *testing.T) {
 	}
 }
 
-func TestDefaultExecFnWithToken_DoesNotInjectForNonGhCommand(t *testing.T) {
-	// `git log` / `git diff` subprocesses (and any other non-gh
-	// command) MUST NOT receive GITHUB_TOKEN — they don't need it
-	// and the file-mount path's whole point is to keep the token's
-	// /proc/<pid>/environ exposure as narrow as possible. With
-	// the basename gating, name="sh" (or "git", or anything else)
-	// leaves Cmd.Env=nil, so the child inherits parent's
-	// GITHUB_TOKEN as-is. Verified here by setting a marker value
-	// on parent and observing it pass through unchanged.
+func TestDefaultExecFnWithToken_StripsGhAuthFromNonGhCommand(t *testing.T) {
+	// `git log` / `git diff` and any other non-gh subprocess must NOT
+	// receive GH_TOKEN or GITHUB_TOKEN even when those vars are present
+	// in the bridge's own os.Environ() (e.g. dev shell, or
+	// --insecure-token-from-env mode). The parent auth vars are
+	// stripped from ALL subprocess envs; the loaded token is injected
+	// only into gh subprocesses. Verified by setting a sentinel
+	// GITHUB_TOKEN in the parent and asserting it does NOT appear in
+	// the sh child's environment.
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("no /bin/sh on this host")
 	}
-	const sentinel = "parent_value_must_pass_through_for_non_gh"
-	t.Setenv("GITHUB_TOKEN", sentinel)
+	t.Setenv("GITHUB_TOKEN", "parent_value_must_be_stripped_for_non_gh")
 
-	fn := chips.DefaultExecFnWithToken("ghp_should_not_be_injected_for_sh")
+	fn := chips.DefaultExecFnWithToken("ghp_not_for_sh_either")
 	out, err := fn(t.Context(), "sh", "-c", `printf "%s" "$GITHUB_TOKEN"`)
 	if err != nil {
 		t.Fatalf("exec sh: %v", err)
 	}
-	if string(out) != sentinel {
-		t.Errorf("non-gh command got injected token:\n  got:  %q\n  want: %q (parent passthrough)", out, sentinel)
+	if string(out) != "" {
+		t.Errorf("non-gh command received GITHUB_TOKEN from parent: %q (should be stripped)", out)
 	}
 }
 
@@ -581,25 +580,25 @@ func TestDefaultExecFnWithToken_DoesNotPolluteParentEnv(t *testing.T) {
 	}
 }
 
-func TestDefaultExecFnWithToken_EmptyTokenSkipsInjection(t *testing.T) {
-	// Empty token → no Cmd.Env override regardless of command name.
-	// Child inherits parent's GITHUB_TOKEN unchanged. The gh stub
-	// is used so we exercise the same code path as the inject
-	// case; only the token value differs.
+func TestDefaultExecFnWithToken_EmptyTokenStillStripsParentGhAuth(t *testing.T) {
+	// Empty token means no injection, but GH_TOKEN / GITHUB_TOKEN
+	// present in the parent env must still be stripped from the
+	// subprocess — even for a gh command. The "empty token" path
+	// corresponds to chips.enabled=false (no secret configured);
+	// real gh calls don't run in that state (stub tools fire
+	// instead), but the subprocess env contract holds regardless.
 	stub := makeGhStub(t)
-	const sentinel = "parent_should_pass_through_for_empty_token"
-	t.Setenv("GITHUB_TOKEN", sentinel)
+	t.Setenv("GITHUB_TOKEN", "parent_must_be_stripped_for_empty_token")
 
 	fn := chips.DefaultExecFnWithToken("")
 	out, err := fn(t.Context(), stub)
 	if err != nil {
 		t.Fatalf("exec gh stub: %v", err)
 	}
-	// Stub prints both GH_TOKEN and GITHUB_TOKEN; GH_TOKEN unset
-	// here so the GITHUB_TOKEN= portion is what we care about.
-	want := "GH_TOKEN=|GITHUB_TOKEN=" + sentinel
-	if string(out) != want {
-		t.Errorf("empty token: child env mismatch:\n  got:  %q\n  want: %q", out, want)
+	// Stub prints GH_TOKEN=$GH_TOKEN|GITHUB_TOKEN=$GITHUB_TOKEN;
+	// both must be empty — parent auth stripped, nothing injected.
+	if string(out) != "GH_TOKEN=|GITHUB_TOKEN=" {
+		t.Errorf("empty token: parent GH auth leaked:\n  got:  %q\n  want: %q", out, "GH_TOKEN=|GITHUB_TOKEN=")
 	}
 }
 

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"klazomenai/bridge/internal/tools/redact"
@@ -34,15 +35,24 @@ func DefaultExecFn() ExecFn {
 // file rather than the bridge process's env (see
 // cmd/bridge/githubauth.go's LoadGitHubToken).
 //
+// Injection is gated on the command name being gh — concretely
+// `filepath.Base(name) == "gh"`. The same ExecFn instance is
+// passed (via registration.go) to both the gh_* tools and the
+// git_log/git_diff tools; only the former invoke the GitHub CLI
+// and need the PAT. Narrowing the injection to gh commands keeps
+// the token off /proc/<git-pid>/environ for `git log` / `git
+// diff` subprocesses (which don't authenticate against the GitHub
+// API; git's local operations need no token).
+//
 // The gh CLI reads GH_TOKEN (preferred) and GITHUB_TOKEN (fallback)
-// from its env to authenticate against the GitHub API. To make the
-// loaded token authoritative — and to guard against a stray
-// GH_TOKEN in the bridge's environment silently overriding it
-// because gh prefers GH_TOKEN — the inherited env is filtered:
-// every GH_TOKEN= / GITHUB_TOKEN= entry from os.Environ() is
-// dropped before we append our own GITHUB_TOKEN entry. Other env
-// vars (PATH, HOME, etc.) survive into the child unchanged so gh
-// can find its dependencies.
+// from its env to authenticate. To make the loaded token
+// authoritative — and to guard against a stray GH_TOKEN in the
+// bridge's environment silently overriding it because gh prefers
+// GH_TOKEN — the inherited env is filtered: every GH_TOKEN= /
+// GITHUB_TOKEN= entry from os.Environ() is dropped before we
+// append our own GITHUB_TOKEN entry. Other env vars (PATH, HOME,
+// etc.) survive into the child unchanged so gh can find its
+// dependencies.
 //
 // Setting GITHUB_TOKEN only on the child cmd's Env keeps the token
 // off the bridge process — it doesn't appear in
@@ -60,25 +70,45 @@ func DefaultExecFn() ExecFn {
 func DefaultExecFnWithToken(token string) ExecFn {
 	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		cmd := exec.CommandContext(ctx, name, args...)
-		if token != "" {
-			parent := os.Environ()
-			env := make([]string, 0, len(parent)+1)
-			for _, e := range parent {
-				// Drop both gh-CLI auth env vars so the injected
-				// value is the only signal the child sees. Without
-				// this filter, a stray GH_TOKEN= in the parent's
-				// env would win against our GITHUB_TOKEN= because
-				// gh prefers GH_TOKEN.
-				if strings.HasPrefix(e, "GH_TOKEN=") || strings.HasPrefix(e, "GITHUB_TOKEN=") {
-					continue
-				}
-				env = append(env, e)
-			}
-			env = append(env, "GITHUB_TOKEN="+token)
+		if env := buildGhChildEnv(os.Environ(), name, token); env != nil {
 			cmd.Env = env
 		}
 		return cmd.Output()
 	}
+}
+
+// buildGhChildEnv constructs the child process environment for a
+// DefaultExecFnWithToken call, or returns nil to signal "let the
+// child inherit the parent's os.Environ() unchanged".
+//
+// Returns nil when token is empty OR when the command's basename
+// is anything other than "gh" — both states mean we don't want to
+// override Cmd.Env and the caller should leave it as Go's default
+// (nil → inherit parent).
+//
+// When the gate passes, the returned slice is parent's os.Environ()
+// with any GH_TOKEN= / GITHUB_TOKEN= entries filtered out, plus a
+// fresh GITHUB_TOKEN= entry carrying the injected value at the end.
+// Extracted as a pure function so the gating + filtering logic can
+// be unit-tested directly without subprocess setup (see
+// exec_internal_test.go).
+func buildGhChildEnv(parent []string, name, token string) []string {
+	if token == "" || filepath.Base(name) != "gh" {
+		return nil
+	}
+	env := make([]string, 0, len(parent)+1)
+	for _, e := range parent {
+		// Drop both gh-CLI auth env vars so the injected value is
+		// the only signal the child sees. Without this filter, a
+		// stray GH_TOKEN= in the parent's env would win against
+		// our GITHUB_TOKEN= because gh prefers GH_TOKEN.
+		if strings.HasPrefix(e, "GH_TOKEN=") || strings.HasPrefix(e, "GITHUB_TOKEN=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	env = append(env, "GITHUB_TOKEN="+token)
+	return env
 }
 
 // RepoAllowlist is a set of allowed org/repo pairs.

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -17,9 +18,43 @@ import (
 type ExecFn func(ctx context.Context, name string, args ...string) ([]byte, error)
 
 // DefaultExecFn returns the production exec function using os/exec.
+// The child process inherits the parent's os.Environ() and gets no
+// extra env vars. Callers that need GITHUB_TOKEN authentication for
+// gh-CLI subprocesses should use DefaultExecFnWithToken instead.
 func DefaultExecFn() ExecFn {
 	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		return exec.CommandContext(ctx, name, args...).Output()
+	}
+}
+
+// DefaultExecFnWithToken returns an ExecFn that injects
+// GITHUB_TOKEN into the child process's environment without
+// exposing the token in the bridge's own os.Environ(). This is the
+// production path when the token is loaded from a mounted secret
+// file rather than the bridge process's env (see
+// cmd/bridge/githubauth.go's LoadGitHubToken).
+//
+// The gh CLI reads GITHUB_TOKEN from its env to authenticate
+// against the GitHub API. Setting it only on the child cmd's Env
+// keeps the token off the bridge process — it doesn't appear in
+// /proc/<bridge-pid>/environ, but it DOES appear in
+// /proc/<gh-pid>/environ during the brief life of each gh
+// subprocess. That window is the minimum any env-passing
+// authentication scheme requires.
+//
+// Passing token="" returns an ExecFn that does NOT add GITHUB_TOKEN
+// to the child env (equivalent to DefaultExecFn). This matches the
+// existing "empty token → stub tools" gate in main.go: if a
+// reduce-confidence caller wires the token through this helper with
+// an empty value, the helper degrades to DefaultExecFn rather than
+// emitting an invalid `GITHUB_TOKEN=` env entry.
+func DefaultExecFnWithToken(token string) ExecFn {
+	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, name, args...)
+		if token != "" {
+			cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+token)
+		}
+		return cmd.Output()
 	}
 }
 

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -81,33 +81,56 @@ func DefaultExecFnWithToken(token string) ExecFn {
 // DefaultExecFnWithToken call, or returns nil to signal "let the
 // child inherit the parent's os.Environ() unchanged".
 //
-// Returns nil when token is empty OR when the command's basename
-// is anything other than "gh" — both states mean we don't want to
-// override Cmd.Env and the caller should leave it as Go's default
-// (nil → inherit parent).
+// GH_TOKEN= / GITHUB_TOKEN= are stripped from ALL subprocess envs
+// (gh and non-gh alike). In production the bridge process never
+// carries those vars — the file-backed token is loaded into memory
+// and injected only into gh subprocesses below. In development,
+// however, the operator's shell may carry GH_TOKEN or
+// --insecure-token-from-env may expose GITHUB_TOKEN; without this
+// broader strip, those values would leak into git_log / git_diff
+// subprocesses that authenticate against nothing (git's local
+// operations need no GitHub PAT).
 //
-// When the gate passes, the returned slice is parent's os.Environ()
-// with any GH_TOKEN= / GITHUB_TOKEN= entries filtered out, plus a
-// fresh GITHUB_TOKEN= entry carrying the injected value at the end.
+// Returns nil (leave Cmd.Env unset → inherit parent) when:
+//   - parent carries no GH auth vars, AND
+//   - no injection is needed (non-gh command, or empty token)
+//
+// Returns a non-nil filtered env otherwise. For gh commands with a
+// non-empty token, GITHUB_TOKEN=<token> is appended at the end so
+// the injected value is the only auth signal the gh subprocess sees.
 // Extracted as a pure function so the gating + filtering logic can
 // be unit-tested directly without subprocess setup (see
 // exec_internal_test.go).
 func buildGhChildEnv(parent []string, name, token string) []string {
-	if token == "" || filepath.Base(name) != "gh" {
-		return nil
+	isGh := filepath.Base(name) == "gh"
+	injectNeeded := isGh && token != ""
+
+	// Optimisation: skip the scan and alloc when we'd inject nothing
+	// and parent carries no GH auth vars to strip (the common case in
+	// production where os.Environ() has no GitHub tokens at all).
+	if !injectNeeded {
+		hasGhAuth := false
+		for _, e := range parent {
+			if strings.HasPrefix(e, "GH_TOKEN=") || strings.HasPrefix(e, "GITHUB_TOKEN=") {
+				hasGhAuth = true
+				break
+			}
+		}
+		if !hasGhAuth {
+			return nil
+		}
 	}
+
 	env := make([]string, 0, len(parent)+1)
 	for _, e := range parent {
-		// Drop both gh-CLI auth env vars so the injected value is
-		// the only signal the child sees. Without this filter, a
-		// stray GH_TOKEN= in the parent's env would win against
-		// our GITHUB_TOKEN= because gh prefers GH_TOKEN.
 		if strings.HasPrefix(e, "GH_TOKEN=") || strings.HasPrefix(e, "GITHUB_TOKEN=") {
 			continue
 		}
 		env = append(env, e)
 	}
-	env = append(env, "GITHUB_TOKEN="+token)
+	if injectNeeded {
+		env = append(env, "GITHUB_TOKEN="+token)
+	}
 	return env
 }
 

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -61,12 +61,15 @@ func DefaultExecFn() ExecFn {
 // subprocess. That window is the minimum any env-passing
 // authentication scheme requires.
 //
-// Passing token="" returns an ExecFn that does NOT add GITHUB_TOKEN
-// to the child env (equivalent to DefaultExecFn). This matches the
-// existing "empty token → stub tools" gate in main.go: if a
-// reduce-confidence caller wires the token through this helper with
-// an empty value, the helper degrades to DefaultExecFn rather than
-// emitting an invalid `GITHUB_TOKEN=` env entry.
+// Passing token="" skips injection but GH_TOKEN= / GITHUB_TOKEN=
+// are still stripped from child envs when those vars appear in the
+// parent (see buildGhChildEnv). In a clean parent environment —
+// the normal production case where os.Environ() carries no GitHub
+// auth — this is functionally equivalent to DefaultExecFn. In dev
+// environments where the shell carries GH_TOKEN, auth vars are
+// stripped from every subprocess regardless. The "empty token →
+// stub tools" gate in main.go means real gh subprocesses don't run
+// in this state anyway.
 func DefaultExecFnWithToken(token string) ExecFn {
 	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		cmd := exec.CommandContext(ctx, name, args...)

--- a/internal/tools/chips/exec.go
+++ b/internal/tools/chips/exec.go
@@ -34,9 +34,18 @@ func DefaultExecFn() ExecFn {
 // file rather than the bridge process's env (see
 // cmd/bridge/githubauth.go's LoadGitHubToken).
 //
-// The gh CLI reads GITHUB_TOKEN from its env to authenticate
-// against the GitHub API. Setting it only on the child cmd's Env
-// keeps the token off the bridge process — it doesn't appear in
+// The gh CLI reads GH_TOKEN (preferred) and GITHUB_TOKEN (fallback)
+// from its env to authenticate against the GitHub API. To make the
+// loaded token authoritative — and to guard against a stray
+// GH_TOKEN in the bridge's environment silently overriding it
+// because gh prefers GH_TOKEN — the inherited env is filtered:
+// every GH_TOKEN= / GITHUB_TOKEN= entry from os.Environ() is
+// dropped before we append our own GITHUB_TOKEN entry. Other env
+// vars (PATH, HOME, etc.) survive into the child unchanged so gh
+// can find its dependencies.
+//
+// Setting GITHUB_TOKEN only on the child cmd's Env keeps the token
+// off the bridge process — it doesn't appear in
 // /proc/<bridge-pid>/environ, but it DOES appear in
 // /proc/<gh-pid>/environ during the brief life of each gh
 // subprocess. That window is the minimum any env-passing
@@ -52,7 +61,21 @@ func DefaultExecFnWithToken(token string) ExecFn {
 	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		cmd := exec.CommandContext(ctx, name, args...)
 		if token != "" {
-			cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+token)
+			parent := os.Environ()
+			env := make([]string, 0, len(parent)+1)
+			for _, e := range parent {
+				// Drop both gh-CLI auth env vars so the injected
+				// value is the only signal the child sees. Without
+				// this filter, a stray GH_TOKEN= in the parent's
+				// env would win against our GITHUB_TOKEN= because
+				// gh prefers GH_TOKEN.
+				if strings.HasPrefix(e, "GH_TOKEN=") || strings.HasPrefix(e, "GITHUB_TOKEN=") {
+					continue
+				}
+				env = append(env, e)
+			}
+			env = append(env, "GITHUB_TOKEN="+token)
+			cmd.Env = env
 		}
 		return cmd.Output()
 	}

--- a/internal/tools/chips/exec_internal_test.go
+++ b/internal/tools/chips/exec_internal_test.go
@@ -1,0 +1,123 @@
+package chips
+
+import (
+	"slices"
+	"testing"
+)
+
+// Internal tests for the buildGhChildEnv helper. These cover the
+// pure gating + filter logic without subprocess setup — gh-CLI
+// integration is exercised in chips_test.go via a stub binary, but
+// edge cases like path-resilient basename matching and exact env
+// ordering are easier to pin here.
+
+func TestBuildGhChildEnv_GatedOnGhBasenameAndNonEmptyToken(t *testing.T) {
+	parent := []string{"PATH=/usr/bin", "HOME=/root"}
+
+	cases := []struct {
+		name      string
+		cmdName   string
+		token     string
+		wantNil   bool
+		wantToken string // value of GITHUB_TOKEN= in the returned env, when non-nil
+	}{
+		{"empty token, gh cmd → nil (inherit)", "gh", "", true, ""},
+		{"non-empty token, git cmd → nil", "git", "tok", true, ""},
+		{"non-empty token, sh cmd → nil", "sh", "tok", true, ""},
+		{"non-empty token, bare 'gh' → inject", "gh", "tok", false, "tok"},
+		{"non-empty token, ./gh → inject (basename matches)", "./gh", "tok", false, "tok"},
+		{"non-empty token, /usr/bin/gh → inject", "/usr/bin/gh", "tok", false, "tok"},
+		{"non-empty token, gh-foo → nil (basename is gh-foo, not gh)", "gh-foo", "tok", true, ""},
+		{"non-empty token, ghs → nil (basename is ghs, not gh)", "ghs", "tok", true, ""},
+		{"empty token, git cmd → nil", "git", "", true, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildGhChildEnv(parent, tc.cmdName, tc.token)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("want nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("want non-nil env, got nil")
+			}
+			if !slices.Contains(got, "GITHUB_TOKEN="+tc.wantToken) {
+				t.Errorf("expected GITHUB_TOKEN=%s in env, got %v", tc.wantToken, got)
+			}
+		})
+	}
+}
+
+func TestBuildGhChildEnv_FiltersGhTokenAndGithubTokenFromParent(t *testing.T) {
+	// Both gh-CLI auth env vars in the parent must be dropped so
+	// the injected value is authoritative.
+	parent := []string{
+		"PATH=/usr/bin",
+		"GH_TOKEN=stray_gh_token_must_be_dropped",
+		"HOME=/root",
+		"GITHUB_TOKEN=stray_github_token_must_be_dropped",
+		"BRIDGE_MARKER=ok",
+	}
+
+	got := buildGhChildEnv(parent, "gh", "ghp_authoritative")
+	if got == nil {
+		t.Fatal("expected non-nil env when gating passes")
+	}
+
+	for _, e := range got {
+		if e == "GH_TOKEN=stray_gh_token_must_be_dropped" {
+			t.Error("parent GH_TOKEN leaked through filter")
+		}
+		if e == "GITHUB_TOKEN=stray_github_token_must_be_dropped" {
+			t.Error("parent GITHUB_TOKEN leaked through filter")
+		}
+	}
+	if !slices.Contains(got, "GITHUB_TOKEN=ghp_authoritative") {
+		t.Errorf("injected GITHUB_TOKEN not present: %v", got)
+	}
+	// Non-gh-auth entries must survive.
+	for _, want := range []string{"PATH=/usr/bin", "HOME=/root", "BRIDGE_MARKER=ok"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("expected %q to survive filter, got %v", want, got)
+		}
+	}
+}
+
+func TestBuildGhChildEnv_AppendsAtEndForLastWriteWinsClarity(t *testing.T) {
+	// The injected GITHUB_TOKEN= must be the LAST element with that
+	// key in the returned env. Linux execve's behaviour when the
+	// same key appears multiple times is implementation-defined,
+	// but every common libc treats "last wins". The filter step
+	// above already prevents duplicates — this test just pins the
+	// append-at-end shape so a future refactor that inserts the
+	// injection somewhere else still produces the expected ordering.
+	parent := []string{"FIRST=a", "SECOND=b"}
+	got := buildGhChildEnv(parent, "gh", "tok")
+	if got == nil {
+		t.Fatal("expected non-nil env")
+	}
+	last := got[len(got)-1]
+	if last != "GITHUB_TOKEN=tok" {
+		t.Errorf("last env entry = %q, want GITHUB_TOKEN=tok", last)
+	}
+}
+
+func TestBuildGhChildEnv_DoesNotMutateParent(t *testing.T) {
+	// The parent slice passed in is os.Environ() — must NOT be
+	// modified by the helper. Pin via a defensive comparison after
+	// the call.
+	parent := []string{
+		"PATH=/usr/bin",
+		"GH_TOKEN=parent_value",
+		"GITHUB_TOKEN=parent_value",
+		"HOME=/root",
+	}
+	parentCopy := slices.Clone(parent)
+	_ = buildGhChildEnv(parent, "gh", "tok")
+	if !slices.Equal(parent, parentCopy) {
+		t.Errorf("buildGhChildEnv mutated parent:\n  got:  %v\n  want: %v", parent, parentCopy)
+	}
+}

--- a/internal/tools/chips/exec_internal_test.go
+++ b/internal/tools/chips/exec_internal_test.go
@@ -2,6 +2,7 @@ package chips
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -48,6 +49,52 @@ func TestBuildGhChildEnv_GatedOnGhBasenameAndNonEmptyToken(t *testing.T) {
 				t.Errorf("expected GITHUB_TOKEN=%s in env, got %v", tc.wantToken, got)
 			}
 		})
+	}
+}
+
+func TestBuildGhChildEnv_StripGhAuthFromNonGhCommands(t *testing.T) {
+	// When the parent env carries GH auth vars, non-gh subprocesses
+	// (git_log, git_diff) must also receive a filtered env — the
+	// broader strip prevents dev-shell GH_TOKEN or --insecure-token-
+	// from-env GITHUB_TOKEN leaking into git subprocesses that don't
+	// need any GitHub auth at all.
+	parent := []string{
+		"PATH=/usr/bin",
+		"GH_TOKEN=dev_token_must_not_leak",
+		"HOME=/root",
+		"GITHUB_TOKEN=another_must_not_leak",
+	}
+
+	for _, cmdName := range []string{"git", "sh", "git_log"} {
+		t.Run(cmdName, func(t *testing.T) {
+			got := buildGhChildEnv(parent, cmdName, "tok")
+			if got == nil {
+				t.Fatal("want non-nil filtered env when parent has GH auth vars, got nil")
+			}
+			for _, e := range got {
+				if strings.HasPrefix(e, "GH_TOKEN=") {
+					t.Errorf("GH_TOKEN leaked into %s subprocess: %v", cmdName, got)
+				}
+				if strings.HasPrefix(e, "GITHUB_TOKEN=") {
+					t.Errorf("GITHUB_TOKEN leaked into %s subprocess: %v", cmdName, got)
+				}
+			}
+			// Non-auth vars must survive.
+			if !slices.Contains(got, "PATH=/usr/bin") || !slices.Contains(got, "HOME=/root") {
+				t.Errorf("non-auth vars filtered out unexpectedly: %v", got)
+			}
+		})
+	}
+}
+
+func TestBuildGhChildEnv_NoGhAuthInParent_NonGhCmd_ReturnsNil(t *testing.T) {
+	// Optimisation path: when the parent carries no GH auth vars and
+	// the command isn't gh (no injection needed), return nil so Cmd.Env
+	// stays unset and the child inherits the parent unchanged —
+	// avoiding a needless alloc on every git_log / git_diff call.
+	parent := []string{"PATH=/usr/bin", "HOME=/root"} // no GH auth
+	if got := buildGhChildEnv(parent, "git", "tok"); got != nil {
+		t.Errorf("expected nil for clean parent + non-gh cmd, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's notes

Bridge-side companion to AKeyRA PR #157 (squash `a1ea2c1`) which landed the chart-side wiring for Chips' GitHub auth (ExternalSecret + deployment mount + `chips.repoAllowlist` env CSV). This PR switches `cmd/bridge/main.go` from reading `GITHUB_TOKEN` env to reading the token from the file the chart mounts. Production: secret-mounted file at `/run/secrets/github/token`. Local dev: env-var fallback behind the `--insecure-token-from-env` CLI flag.

## Acceptance criteria

Walking #141 + #142 against this PR:

| AC item | Source | Status |
|---|---|---|
| `cmd/bridge/main.go` reads GitHub token from `/run/secrets/github/token` (path configurable via flag/env for local dev) | #141 | ✅ `LoadGitHubToken` reads from `GITHUB_TOKEN_FILE` env (default `DefaultGitHubTokenPath = /run/secrets/github/token`) |
| Fall-through to env var preserved only behind a `--insecure-token-from-env` dev flag (off by default; logs a warning when used) | #141 | ✅ `flag.Bool("insecure-token-from-env", false, ...)`; default off; emits one-shot `slog.Warn` when active |
| `helm/bridge/templates/deployment.yaml` mounts the K8s Secret `bridge-chips-github` as a read-only volume at `/run/secrets/github` | #141 | ✅ Delivered in AKeyRA PR #157 |
| Volume mount gated on `chips.enabled` Helm value | #141 | ✅ Delivered in AKeyRA PR #157 |
| Token is never logged, even in debug mode | #141 | ✅ Both loader code paths emit only metadata (`path`, `present` bool, `rune_count`). Two dedicated tests (`TestLoadGitHubToken_TokenNeverLoggedFromFile` + `…FromEnv`) capture slog output and assert the literal secret string is absent |
| Existing read-only Chips tools continue to work after the change (regression test) | #141 | ✅ Full internal suite green (15 packages); chips test suite at `internal/tools/chips/` unchanged and passing. The threading from `LoadGitHubToken` → `chipstools.RegisterChipsTools` preserves the existing `ghToken != "" && chipsRepoCSV != ""` gate exactly |
| `chips.repoAllowlist` in `helm/bridge/values.yaml` (list of `<owner>/<repo>` strings) | #142 | ✅ Delivered in AKeyRA PR #157 |
| `helm/bridge/templates/deployment.yaml` renders the list to env var (CSV) | #142 | ✅ Delivered in AKeyRA PR #157 |
| `cmd/bridge/main.go` parsing handles both sources during the transition (or commit a single source of truth — your choice, justify in PR) | #142 | ✅ Single source of truth: `CHIPS_REPO_ALLOWLIST` env CSV, parsed by `chipstools.ParseRepoAllowlist`. Justified below in design-note #4 |
| Empty list → Chips refuses all repos (fail-closed) | #142 | ✅ Inherited unchanged from `chipstools.ParseRepoAllowlist("")` → empty allowlist → `RepoAllowlist.Check` returns "not in allowed list" for every org/repo |
| Default value in `values.yaml`: empty list | #142 | ✅ Delivered in AKeyRA PR #157 |
| `helm template` golden test covers `chips.repoAllowlist` rendering with 0, 1, and 6 entries | #142 | ✅ Delivered in AKeyRA PR #157 (`helm/bridge/tests/deployment_chips_test.yaml`, 3 dedicated cases) |
| Existing `CHIPS_REPO_ALLOWLIST` env-var path either deprecated cleanly or kept with documented precedence | #142 | ✅ Kept; chart-supplied. Documented in PR design notes + `TestLoadGitHubToken_FileTakesPrecedenceOverEnv` (which pins that `GITHUB_TOKEN` env is irrelevant when the file path is consulted — env is consulted only under the dev flag) |

**Score: 13/13 AC items met across both issues.**

## Design notes worth review

1. **`LoadGitHubToken` returns `("", nil)` on missing file rather than erroring.** Default chart state is `chips.enabled=false`, which means no Secret is mounted and the file is absent. The bridge needs to start cleanly in that state and register stub tools, identical to pre-#141 when `GITHUB_TOKEN` env was unset. Surfacing the missing-file as an error would force every operator running `chips.enabled=false` to special-case it. Real IO errors (permission denied, etc.) still surface — only `fs.ErrNotExist` is treated as a soft empty.

2. **Token-load errors don't fail-start.** `main.go` logs the error via `slog.Error` and falls through to empty-token + stub-tools. Anthropic key remains the only hard-required secret (the bridge exits if it can't be read); Chips is a feature on top. A misconfigured `GITHUB_TOKEN_FILE` produces visible diagnostics + stubs rather than a crash loop.

3. **`--insecure-token-from-env` is the only CLI flag bridge accepts.** All other config is env-based, matching the existing pattern. The flag name is deliberately wordy ("insecure") to discourage production use. Production deployments leave it off; the chart doesn't pass any args (the Dockerfile ENTRYPOINT is `["/bridge"]`).

4. **Allowlist source-of-truth decision.** #142 left the call between env-var-only and dual-source open. Choosing env-var-only (CSV from `CHIPS_REPO_ALLOWLIST`, as the chart now supplies via #157):
   - Preserves the existing `chipstools.ParseRepoAllowlist` pipeline — zero churn in chips/exec.go.
   - Avoids adding a second config surface (config file) for what's a small list (~6 repos).
   - Matches the established bridge pattern (every other config is env).
   - If the allowlist outgrows ~10 entries we can revisit; for now CSV is simpler.

5. **File-takes-precedence-over-env is unconditional in the file path.** When `--insecure-token-from-env` is NOT set, `GITHUB_TOKEN` env is **completely ignored**. There's no fallthrough that would silently switch sources if the file is empty/missing. The dev flag is the only way to read env, and it's clearly marked "DEV ONLY" + logs a warning.

6. **Whitespace + trailing-newline trim on the token.** K8s Secrets mounted via the helm chart can include a trailing newline depending on how the secret was created from raw bytes. The loader trims so the value passed to `gh` is clean (gh CLI rejects tokens with whitespace).

## Test plan

- [x] `CGO_ENABLED=0 go vet -tags goolm ./...` clean
- [x] `CGO_ENABLED=0 go test -tags goolm -count=1 ./...` — all 15 internal packages green
- [x] `cmd/bridge/githubauth.go` `LoadGitHubToken` at 100% line coverage (verified via `go tool cover -func`)
- [x] 11 unit tests covering: custom path, trailing-newline trim, whitespace trim, missing file, empty file, default-path fallback, file-vs-env precedence, permission error, env-path happy path, env-path empty, two token-never-logged tests
- [ ] CI green on the PR (`test`, `license-audit`, `docker`, `lint-workflows`, `skills-drift`, `coverage-gate`)
- [ ] Post-merge image release; post-Vault-ceremony chart flip (`chips.enabled: true` + `repoAllowlist`) + image bump; ArgoCD deploys; voice smoke: "Chips, list open PRs in klazomenai/bridge" returns real PR titles instead of the stub message

## Rollout sequence (operator-driven, post-merge)

1. ✅ AKeyRA chart wiring (`a1ea2c1`, this PR's companion — already on AKeyRA `main`).
2. 📋 **AKeyRA #114** — Vault root-token ceremony writes the PAT to `secret/data/bridge/chips-github-pat` key `token`. Operator-manual; not gated on this PR.
3. 📋 This PR merges → new bridge image released via release-please.
4. 📋 Operator commits an AKeyRA values flip: `chips.enabled: true` + populated `chips.repoAllowlist` (the six klazomenai repos per #114's AC) + bumps `image.tag` to the new release. ArgoCD reconciles → ExternalSecret syncs → K8s Secret created → new bridge image reads `/run/secrets/github/token` → Chips activated.

## Out of scope / follow-up

- **AKeyRA #114** — Vault root-token ceremony. Operator-manual; required before the production flip in step 4 above but not gated on this PR.
- **#173** — orchestrator slog leaks follow-up (separate scope, filed during #129's review).
- **Per-crew NetworkPolicy / ServiceAccount split (#116, #117)** — separate AKeyRA work under epic #113; Phase 6 of the master plan, not B.1.

Closes #141
Closes #142
Refs #115
Refs #113
Refs #114
