### PR TITLE
test(maren): assert secrets denylist fires before K8s API for all variants 🔐

### DIFF
--- a/internal/tools/maren/maren_test.go
+++ b/internal/tools/maren/maren_test.go
@@ -10,6 +10,9 @@ import (
 	"klazomenai/bridge/internal/tools/maren"
 )
 
+// All tools in this package wrap an ExecFn; tests inject mockExec rather than
+// invoking kubectl or helm against a live cluster.
+
 // mockExec returns a mock ExecFn that records calls and returns canned output.
 func mockExec(output string, err error) (maren.ExecFn, *[]string) {
 	var calls []string

--- a/internal/tools/maren/maren_test.go
+++ b/internal/tools/maren/maren_test.go
@@ -97,6 +97,44 @@ func TestKubectlGetDeniedResource(t *testing.T) {
 	}
 }
 
+// TestKubectlGetSecretsAllVariantsBlocked asserts that every case/plurality
+// variant of "secrets" is rejected before the K8s API is touched. This is the
+// defence-in-depth regression test that pairs with the ClusterRole tightening
+// in bridge#127: even if the RBAC permission is accidentally reinstated, the
+// code layer independently refuses the call.
+func TestKubectlGetSecretsAllVariantsBlocked(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantMsg string
+	}{
+		// Plural forms → ToLower → "secrets" → hits deniedResources
+		{"secrets", "not permitted"},
+		{"Secrets", "not permitted"},
+		{"SECRETS", "not permitted"},
+		// Singular forms → ToLower → "secret" → misses allowedResources
+		{"secret", "not in the allowed list"},
+		{"Secret", "not in the allowed list"},
+		{"SECRET", "not in the allowed list"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			fn, calls := mockExec("", nil)
+			tool := maren.NewKubectlGetTool(fn)
+			input := mustJSON(t, map[string]string{"resource_type": tc.input})
+			_, err := tool.Execute(t.Context(), input)
+			if err == nil {
+				t.Fatalf("expected error for resource_type %q, got nil", tc.input)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("resource_type %q: expected error containing %q, got: %v", tc.input, tc.wantMsg, err)
+			}
+			if len(*calls) != 0 {
+				t.Errorf("resource_type %q: exec was called %d time(s); K8s API must not be touched before the denylist check", tc.input, len(*calls))
+			}
+		})
+	}
+}
+
 func TestKubectlGetUnknownResource(t *testing.T) {
 	fn, _ := mockExec("", nil)
 	tool := maren.NewKubectlGetTool(fn)


### PR DESCRIPTION
## Summary

Defence-in-depth regression test asserting that every case/plurality variant of `secrets` is rejected before the K8s API is touched — the code-layer companion to the ClusterRole tightening in the AKeyRA companion PR.

Refs #127

## AC walkthrough

| AC item | Status |
|---|---|
| Regression test: `secrets` variants rejected before K8s API call | ✅ `TestKubectlGetSecretsAllVariantsBlocked` — 6 subtests (secrets/Secrets/SECRETS via denylist; secret/Secret/SECRET via allowlist miss); each asserts `len(*calls)==0` |
| Existing `helm_status` happy-path test still passes | ✅ full suite 14/14 |
| ClusterRole `secrets` removal + per-namespace Roles | 🔲 companion PR in `klazomenai/AKeyRA` |

## Test plan

- [x] `go test -tags goolm -count=1 ./internal/tools/maren/` — 6 new subtests pass
- [x] `go test -tags goolm -count=1 ./internal/...` — 14/14 packages

## Quartermaster's Notes

`strings.ToLower` normalises all input before the denylist check, so:
- `secrets`, `Secrets`, `SECRETS` → `"secrets"` → `deniedResources` → "not permitted"
- `secret`, `Secret`, `SECRET` → `"secret"` → not in `allowedResources` → "not in the allowed list"

Both paths return an error before `execFn` is called. The `len(*calls)==0` assertion in each subtest makes this explicit — the test would fail if the check order were accidentally inverted or removed.

The companion AKeyRA PR removes `secrets` from the ClusterRole's core-API rule and adds per-namespace `Role`+`RoleBinding` for each namespace in `lookout.namespaceAllowlist`, scoping Helm release Secret access from cluster-wide to allowlisted namespaces only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
